### PR TITLE
docs: add CLAUDE.md and document Tailscale NAT keepalive fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ CI runs `docker compose config` for every stack on all pushes. The immich stack 
 ## Stack Layout
 
 Seven compose stacks under `docker-compose/`:
+
 - `pihole` - DNS authority (port 53 on host)
 - `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
 - `jellyfin-arr-stack` - Media: Jellyfin (NVIDIA GPU), Radarr, Sonarr, Prowlarr, Bazarr, Homarr, qBittorrent, Seerr
@@ -85,3 +86,9 @@ curl -vk --resolve <service>.homelab.ansh-info.com:443:<TAILSCALE_IP> https://<s
 - Pi-hole v6 requires `FTLCONF_misc_etc_dnsmasq_d: "true"` to load `/etc/dnsmasq.d`
 - Nextcloud AIO container name `nextcloud-aio-mastercontainer` is immutable
 - Immich compose references `stack.env` via `env_file:` (not `.env`)
+
+## Further Context
+
+- `AGENTS.md` - detailed rules for service addition, storage layout, NPM config, and documentation updates
+- `docs/NETWORKING.md` - full networking model, Tailscale NAT keepalive fix, and failure diagnostics
+- `docs/OPERATIONS.md` - day-two operations, incident playbooks, and backup priorities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+Source of truth for rebuilding and operating a personal homelab. Contains Docker Compose stack definitions, dotfiles (nvim, tmux, kitty, aerospace, zsh), and operational documentation. Not a software project with application code - it is infrastructure-as-config.
+
+## Architecture
+
+Private-first homelab accessed exclusively through Tailscale:
+
+1. Tailscale provides private network connectivity
+2. Tailscale Split DNS sends `*.homelab.ansh-info.com` queries to Pi-hole
+3. Pi-hole resolves hostnames to the homelab Tailscale IP
+4. Nginx Proxy Manager routes traffic to containers on the shared `proxy` Docker network
+
+Primary deployment interface is Portainer. Docker CLI is the fallback for inspection and recovery.
+
+## Validation Commands
+
+```bash
+# Validate a specific compose stack (run from its directory)
+cd docker-compose/<stack-name> && docker compose config
+
+# Validate all stacks like CI does (needs env vars)
+PIHOLE_PASSWORD=placeholder TAILSCALE_IP=127.0.0.1 \
+UPLOAD_LOCATION=/tmp/u DB_DATA_LOCATION=/tmp/d \
+DB_PASSWORD=x DB_USERNAME=x DB_DATABASE_NAME=x \
+OPENCLAW_GATEWAY_TOKEN=x \
+docker compose -f docker-compose/<stack>/docker-compose.yml config
+
+# Validate aerospace TOML syntax
+python3 -c "import tomllib, pathlib; tomllib.load(pathlib.Path('aerospace/aerospace.toml').open('rb'))"
+```
+
+CI runs `docker compose config` for every stack on all pushes. The immich stack requires its `stack.env` file in the same directory.
+
+## Key Conventions
+
+- **Storage paths**: All persistent bind mounts under `/mnt/ssd/docker-volumes/<stack-or-service>/...` - never introduce scattered storage roots
+- **Networking**: Reverse-proxied services join the external `proxy` network. Never bind ports to the Tailscale IP directly (boot-time race condition)
+- **Formatting**: No em dashes - use short hyphens only
+- **Commits**: Conventional commits (`feat:`, `fix:`, `docs:`, `chore:`, `ci:`, `refactor:`, `perf:`). Semantic release bumps version automatically on main
+- **Co-authors**: All commits include co-author trailers for `anshkumar.info@gmail.com` and `apoorvaagupta.info@gmail.com`
+- **New stacks**: Place at `docker-compose/<name>/docker-compose.yml`, update README.md, `docs/README.md`, `docs/stacks/`, `docs/VARIABLES.md`, and the CI validation matrix in `.github/workflows/docker-compose-validate.yml`
+
+## Stack Layout
+
+Seven compose stacks under `docker-compose/`:
+- `pihole` - DNS authority (port 53 on host)
+- `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
+- `jellyfin-arr-stack` - Media: Jellyfin (NVIDIA GPU), Radarr, Sonarr, Prowlarr, Bazarr, Homarr, qBittorrent, Seerr
+- `immich` - Photo management (uses `stack.env` for config)
+- `nextcloud-aio` - Cloud storage (two NPM hosts: admin + app)
+- `openclaw` - AI assistant gateway (stateful, manual updates only)
+- `watchtower` - Auto-updates for other containers
+
+## Dotfiles
+
+- `nvim/` - LazyVim-based Neovim config
+- `tmux/.tmux.conf` - Tmux configuration
+- `kitty/kitty.conf` - Kitty terminal config
+- `aerospace/aerospace.toml` - AeroSpace tiling WM for macOS
+- `zshrc/.zshrc` - Zsh config with lazy loading
+
+## Release Process
+
+Python semantic-release runs on main via GitHub Actions. Version tracked in `pyproject.toml`. The `CHANGELOG.md` is auto-generated.
+
+## Verification After Changes
+
+```bash
+# Check compose files and docs agree
+rg -n 'old-path-or-old-name' docker-compose docs README.md
+
+# End-to-end DNS and proxy check (from tailnet client)
+dig +short <service>.homelab.ansh-info.com @<TAILSCALE_IP>
+curl -vk --resolve <service>.homelab.ansh-info.com:443:<TAILSCALE_IP> https://<service>.homelab.ansh-info.com/
+```
+
+## Notable Exceptions
+
+- Jellyfin requires `runtime: nvidia` and NVIDIA env vars - do not remove
+- Pi-hole v6 requires `FTLCONF_misc_etc_dnsmasq_d: "true"` to load `/etc/dnsmasq.d`
+- Nextcloud AIO container name `nextcloud-aio-mastercontainer` is immutable
+- Immich compose references `stack.env` via `env_file:` (not `.env`)

--- a/docs/NETWORKING.md
+++ b/docs/NETWORKING.md
@@ -477,6 +477,130 @@ When debugging, use this order:
 
 This sequence prevents guessing and keeps each failure isolated to a specific layer.
 
+## Tailscale Direct Connection and NAT Keepalive
+
+### Problem: DERP Relay Fallback
+
+Tailscale prefers direct peer-to-peer WireGuard connections between devices. When direct connections cannot be established or maintained, Tailscale falls back to DERP relay servers. DERP relays are bandwidth-limited and add latency, making streaming services like Jellyfin unusable.
+
+Symptoms of DERP fallback:
+
+- `tailscale ping homelab` shows `via DERP(blr)` instead of a direct IP
+- Jellyfin buffering even at low bitrates (1.5-3 Mbps)
+- Latency spikes of 700-1000ms instead of normal ~200ms for international links
+
+### Root Cause: Jio Router NAT Expiry
+
+The Jio Centrum router (192.168.29.1) aggressively expires UDP NAT mappings after 30-60 seconds of inactivity. When the mapping expires, Tailscale loses the direct path and falls back to DERP until it can re-establish a connection through NAT hole-punching.
+
+UPnP is enabled on the router but non-functional (`tailscale netcheck` reports empty PortMapping). The router admin password is not the default (`admin`/`Jiocentrum`) and cannot be reset remotely.
+
+### Current Fix: Systemd Keepalive Service
+
+A systemd service on the homelab pings all tailnet devices every 25 seconds, preventing the NAT mapping from expiring.
+
+Service file: `/etc/systemd/system/tailscale-keepalive.service`
+
+```ini
+[Unit]
+Description=Tailscale NAT keepalive
+After=tailscaled.service
+Wants=tailscaled.service
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -c 'while true; do /usr/bin/tailscale ping --c 1 ansh-macbookpro-work >/dev/null 2>&1; /usr/bin/tailscale ping --c 1 ansh-macbookpro >/dev/null 2>&1; /usr/bin/tailscale ping --c 1 ansh-iphone16promax >/dev/null 2>&1; /usr/bin/tailscale ping --c 1 apoorva-macbook >/dev/null 2>&1; /usr/bin/tailscale ping --c 1 apoorva-oneplus >/dev/null 2>&1; sleep 25; done'
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+How it works:
+
+- Sends a Tailscale ping to each device every 25 seconds
+- Keeps the router NAT mapping alive by generating regular UDP traffic
+- Failed pings to offline devices are silently ignored
+- When a device comes online, the next ping cycle (within 25 seconds) establishes a direct path
+
+Management commands:
+
+```bash
+# Check status
+sudo systemctl status tailscale-keepalive
+
+# Restart after editing device list
+sudo systemctl daemon-reload
+sudo systemctl restart tailscale-keepalive
+
+# Add a new device: edit the service file ExecStart line, then restart
+```
+
+### Verification
+
+From a client device:
+
+```bash
+# Should show "via <IP>:41641" not "via DERP(...)"
+tailscale ping homelab
+
+# Bandwidth test (start iperf3 -s -B 100.123.147.108 on homelab first)
+iperf3 -c 100.123.147.108 -t 10
+```
+
+Expected results:
+
+- Direct connection: `via 49.43.x.x:41641 in ~200ms`
+- Bandwidth: ~20-30 Mbps (sufficient for 1080p streaming)
+
+### Permanent Fix: Port Forward (When Router Access is Available)
+
+The keepalive is a workaround. The permanent fix is a single port forward rule on the Jio router:
+
+- Protocol: UDP
+- External port: 41641
+- Internal IP: 192.168.29.133
+- Internal port: 41641
+
+This tells the router to always accept incoming Tailscale traffic - no keepalive needed.
+
+After adding the port forward:
+
+```bash
+sudo systemctl disable --now tailscale-keepalive
+sudo rm /etc/systemd/system/tailscale-keepalive.service
+sudo systemctl daemon-reload
+```
+
+Verify with `tailscale netcheck` on the homelab - PortMapping should show the forwarded port, and the external IPv4 should report `:41641` instead of a random port.
+
+### Tailscale Configuration on the Homelab
+
+Current settings:
+
+- Tailscale port: 41641 (set in `/etc/default/tailscaled`)
+- UFW allows UDP 41641 for Tailscale
+- Stateful filtering disabled (`NoStatefulFiltering: true`)
+- Exit node advertised (`AdvertiseRoutes: 0.0.0.0/0, ::/0`)
+- Accept DNS disabled (`CorpDNS: false`) to preserve host resolver
+
+### Diagnostic Commands (Run on Homelab)
+
+```bash
+# Check if Tailscale is using the correct port
+sudo ss -ulnp | grep 41641
+
+# Check NAT mapping and external IP
+tailscale netcheck 2>&1 | grep "IPv4\|PortMapping"
+
+# Check keepalive service
+sudo systemctl status tailscale-keepalive
+
+# Check direct connectivity to a specific peer
+tailscale ping ansh-macbookpro-work
+```
+
 ## Related Docs
 
 - [SETUP.md](SETUP.md)


### PR DESCRIPTION
## Summary

- Add CLAUDE.md for Claude Code guidance with validation commands, conventions, and architecture overview
- Document the Tailscale DERP relay fallback issue and the systemd keepalive workaround in docs/NETWORKING.md
- Include diagnostic commands, verification steps, and the permanent port forward cleanup route

## Context

Jellyfin streaming was unusable (~1.5-3 Mbps via DERP relay) due to the Jio router aggressively expiring UDP NAT mappings. A systemd keepalive service that pings all tailnet devices every 25 seconds maintains the direct WireGuard connection (~20-30 Mbps).

## Test plan

- [ ] Verify `tailscale ping homelab` shows direct connection (not DERP)
- [ ] Confirm Jellyfin streams at 1080p without buffering
- [ ] Validate markdown renders correctly on GitHub