### PR TITLE
fix: security hardening and documentation accuracy sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ cython_debug/
 
 # Local planning and note artifacts
 docs/superpowers/
+
+# Stack environment files (may contain secrets)
+docker-compose/**/stack.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ If a new stack is added, place it under:
 
 - `docker-compose/<stack-name>/docker-compose.yml`
 
-If the stack needs an env file, keep it in the same folder.
+If the stack needs an env file, keep it in the same folder. Note that `stack.env` files are gitignored to prevent accidental secret commits - they must be created manually on fresh clones.
 
 ## Deployment Model
 
@@ -353,6 +353,12 @@ That includes:
 - `NVIDIA_DRIVER_CAPABILITIES=compute,video,utility`
 
 Agents should not remove or rewrite this casually.
+
+### Watchtower
+
+- Docker socket is mounted read-only (`:ro`) as a deliberate security constraint
+- Do not add `--debug` to the command unless actively troubleshooting
+- Do not change the socket mount to read-write without explicit user approval
 
 ## Source Docs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ docker compose -f docker-compose/<stack>/docker-compose.yml config
 python3 -c "import tomllib, pathlib; tomllib.load(pathlib.Path('aerospace/aerospace.toml').open('rb'))"
 ```
 
-CI runs `docker compose config` for every stack on all pushes. The immich stack requires its `stack.env` file in the same directory.
+CI runs `docker compose config` for every stack on all pushes. The immich stack requires its `stack.env` file in the same directory (gitignored - must be created manually on fresh clones).
 
 ## Key Conventions
 
@@ -86,6 +86,7 @@ curl -vk --resolve <service>.homelab.ansh-info.com:443:<TAILSCALE_IP> https://<s
 - Pi-hole v6 requires `FTLCONF_misc_etc_dnsmasq_d: "true"` to load `/etc/dnsmasq.d`
 - Nextcloud AIO container name `nextcloud-aio-mastercontainer` is immutable
 - Immich compose references `stack.env` via `env_file:` (not `.env`)
+- Watchtower docker.sock is mounted read-only (`:ro`) - do not change to read-write
 
 ## Further Context
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Start here for the detailed rebuild docs:
 ## Repository Layout
 
 - [docker-compose](docker-compose): Portainer stack definitions and service-specific compose files
-- [utils](utils): helper scripts
 - [docs](docs): rebuild and operations documentation
 
 ## Operating Model

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -150,8 +150,8 @@ services:
     ports:
       # - 8096:8096
       - 8920:8920
-      - 7359:7359/udp # discovery
-      - 1900:1900/udp # SSDP (if you use DLNA)
+      # - 7359:7359/udp # discovery
+      # - 1900:1900/udp # SSDP (if you use DLNA)
     networks:
       - proxy
     restart: unless-stopped
@@ -161,12 +161,9 @@ services:
     container_name: seerr
     init: true
     environment:
-      - LOG_LEVEL=debug
+      - LOG_LEVEL=info
       - TZ=Etc/UTC
       - PORT=5055
-    dns:
-      - 1.1.1.1
-      - 8.8.8.8
     # ports:
     #   - 5055:5055
     networks:

--- a/docker-compose/watchtower/docker-compose.yml
+++ b/docker-compose/watchtower/docker-compose.yml
@@ -7,9 +7,8 @@ services:
       - TZ=Asia/Kolkata
       - DOCKER_API_VERSION=1.40
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     command:
       - --interval
       - "86400"
       - --cleanup
-      - --debug

--- a/docs/stacks/jellyfin-arr-stack.md
+++ b/docs/stacks/jellyfin-arr-stack.md
@@ -106,7 +106,7 @@ Current important service details from the compose file:
   - torrent port `6881` exposed on host
   - attached to `${PROXY_NETWORK}`
 - `homarr`
-  - currently present but not attached to `${PROXY_NETWORK}` in the compose file
+  - dashboard layer attached to `${PROXY_NETWORK}`
 - `lidarr`
   - currently commented out in the checked-in compose file
 - `plex`
@@ -210,8 +210,8 @@ Expected reverse-proxy targets include:
 Current exceptions in the compose file:
 
 - `qbittorrent` publishes `6881/tcp` and `6881/udp`
-- `jellyfin` publishes `8920`, `7359/udp`, and `1900/udp`
-- `homarr` is present but has no host ports and is not attached to `${PROXY_NETWORK}`
+- `jellyfin` publishes `8920` (discovery ports `7359/udp` and `1900/udp` are disabled)
+- `homarr` has no host ports but is attached to `${PROXY_NETWORK}`
 - `lidarr` and `plex` are currently commented out
 
 These direct exposures are stack-specific exceptions, not the primary ingress pattern.
@@ -304,9 +304,9 @@ Look especially for:
 docker network inspect ${PROXY_NETWORK}
 ```
 
-For normal NPM access, services like `seerr`, `radarr`, `sonarr`, `prowlarr`, `bazarr`, `jellyfin`, and `qbittorrent` should appear on `${PROXY_NETWORK}`.
+For normal NPM access, services like `seerr`, `radarr`, `sonarr`, `prowlarr`, `bazarr`, `jellyfin`, `qbittorrent`, and `homarr` should appear on `${PROXY_NETWORK}`.
 
-Do not assume `homarr` will appear there unless the compose file is changed. `lidarr` and `plex` are currently commented out.
+`lidarr` and `plex` are currently commented out.
 
 ### Confirm Seerr health
 
@@ -390,6 +390,7 @@ For the active services in this stack, the practical NPM pattern is:
 | `prowlarr.${DOMAIN_ROOT}` | `http` | `prowlarr` | `9696` |
 | `bazarr.${DOMAIN_ROOT}` | `http` | `bazarr` | `6767` |
 | `jellyfin.${DOMAIN_ROOT}` | `http` | `jellyfin` | `8096` |
+| `homarr.${DOMAIN_ROOT}` | `http` | `homarr` | `7575` |
 
 Recommended NPM toggles for these entries:
 
@@ -403,12 +404,11 @@ Recommended NPM toggles for these entries:
 - `HSTS Enabled`: enabled
 - `HSTS Sub-domains`: enabled
 
-Optional entries only if those services are enabled and attached to `${PROXY_NETWORK}`:
+Optional entries (only if those services are enabled and attached to `${PROXY_NETWORK}`):
 
 | Public hostname | Scheme | Forward Hostname / IP | Forward Port |
 | --- | --- | --- | --- |
 | `lidarr.${DOMAIN_ROOT}` | `http` | `lidarr` | `8686` |
-| `homarr.${DOMAIN_ROOT}` | `http` | `homarr` | `7575` |
 | `plex.${DOMAIN_ROOT}` | `http` | `plex` | `32400` |
 
 Before adding an NPM entry for a service, confirm that:
@@ -473,7 +473,6 @@ Likely causes:
 
 Current examples from the compose file:
 
-- `homarr` is present but does not currently join `${PROXY_NETWORK}`
 - `lidarr` is currently commented out
 - `plex` is currently commented out
 

--- a/docs/stacks/watchtower.md
+++ b/docs/stacks/watchtower.md
@@ -17,7 +17,7 @@ Watchtower monitors Docker containers and updates eligible images automatically.
 Watchtower depends on:
 
 - Docker and Portainer
-- access to `/var/run/docker.sock`
+- read-only access to `/var/run/docker.sock` (mounted with `:ro`)
 - acceptance that Watchtower can evaluate any running container visible through the Docker socket
 
 ## Placeholder Variables
@@ -39,17 +39,15 @@ ${TZ}=Asia/Kolkata
 Current important details from the stack:
 
 - image: `containrrr/watchtower`
-- Docker socket mounted from the host
+- Docker socket mounted read-only from the host
 - interval set to `86400` seconds
 - `--cleanup` enabled
-- `--debug` enabled
 
 Meaning:
 
 - updates are not limited to labeled containers by the checked-in compose file
 - Watchtower can evaluate and update running containers beyond the stacks defined in this repo
 - old images are cleaned up after updates
-- logs are verbose enough for debugging
 
 ## Portainer Deployment
 


### PR DESCRIPTION
## Summary

- Restrict Watchtower docker.sock mount to read-only (`:ro`) to prevent full host compromise via supply chain attacks
- Add `stack.env` to `.gitignore` to prevent accidental secret commits
- Comment out Jellyfin DLNA/discovery ports (7359, 1900) that bypass UFW via Docker iptables
- Remove `--debug` from Watchtower and change Seerr `LOG_LEVEL` from debug to info
- Remove hardcoded external DNS (1.1.1.1, 8.8.8.8) from Seerr so it uses Pi-hole
- Update all documentation to reflect current state

## Security Fixes

| Fix | Severity | Description |
|-----|----------|-------------|
| Watchtower socket `:ro` | CRITICAL | Limits blast radius if container image is compromised |
| `stack.env` gitignored | CRITICAL | Prevents accidental commits of database passwords and API tokens |
| Jellyfin discovery ports disabled | HIGH | Ports 7359/1900 bypassed UFW via Docker iptables rules |
| Watchtower `--debug` removed | HIGH | Debug logs can expose registry credentials and image metadata |
| Seerr `LOG_LEVEL=info` | HIGH | Debug logs expose internal API tokens and user activity |
| Seerr hardcoded DNS removed | MEDIUM | Now uses Pi-hole instead of bypassing it with 1.1.1.1/8.8.8.8 |

## Documentation Updates

| File | Changes |
|------|---------|
| `README.md` | Removed stale `utils/` directory reference |
| `CLAUDE.md` | Added stack.env gitignore note, Watchtower `:ro` in Notable Exceptions |
| `AGENTS.md` | Added stack.env gitignore note, Watchtower Known Exception section |
| `docs/stacks/watchtower.md` | Removed `--debug` reference, documented `:ro` mount |
| `docs/stacks/jellyfin-arr-stack.md` | Fixed 4 stale claims (homarr now on proxy network), updated Jellyfin ports, moved homarr to main NPM table |

## Test plan

- [x] `docker compose config` passes for watchtower stack
- [x] `docker compose config` passes for jellyfin-arr-stack
- [ ] Watchtower still pulls and updates images with `:ro` socket
- [ ] Seerr resolves external APIs (TMDB, etc.) without hardcoded DNS
- [ ] Jellyfin streaming works through NPM (no dependency on removed discovery ports)
- [ ] All markdown renders correctly on GitHub