### PR TITLE
feat: add Actual Budget stack for personal finance

### DIFF
--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -82,6 +82,17 @@ jobs:
             db_database_name: placeholder
             pihole_password: placeholder
             tailscale_ip: 127.0.0.1
+          - name: actual-budget
+            path: docker-compose/actual-budget
+            gpu: false
+            host_mounts: true
+            upload_location: /tmp/uploads-unused
+            db_data_location: /tmp/db-unused
+            db_password: placeholder
+            db_username: placeholder
+            db_database_name: placeholder
+            pihole_password: placeholder
+            tailscale_ip: 127.0.0.1
           - name: watchtower
             path: docker-compose/watchtower
             gpu: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Current stack layout:
 - `docker-compose/immich`
 - `docker-compose/nextcloud-aio`
 - `docker-compose/openclaw`
+- `docker-compose/actual-budget`
 - `docker-compose/watchtower`
 
 If a new stack is added, place it under:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ CI runs `docker compose config` for every stack on all pushes. The immich stack 
 
 ## Stack Layout
 
-Seven compose stacks under `docker-compose/`:
+Eight compose stacks under `docker-compose/`:
 
 - `pihole` - DNS authority (port 53 on host)
 - `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
@@ -55,6 +55,7 @@ Seven compose stacks under `docker-compose/`:
 - `immich` - Photo management (uses `stack.env` for config)
 - `nextcloud-aio` - Cloud storage (two NPM hosts: admin + app)
 - `openclaw` - AI assistant gateway (stateful, manual updates only)
+- `actual-budget` - Personal finance and envelope budgeting
 - `watchtower` - Auto-updates for other containers
 
 ## Dotfiles

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The main service definitions live under [docker-compose](docker-compose):
 - [docker-compose/immich/docker-compose.yml](docker-compose/immich/docker-compose.yml)
 - [docker-compose/nextcloud-aio/docker-compose.yml](docker-compose/nextcloud-aio/docker-compose.yml)
 - [docker-compose/openclaw/docker-compose.yml](docker-compose/openclaw/docker-compose.yml)
+- [docker-compose/actual-budget/docker-compose.yml](docker-compose/actual-budget/docker-compose.yml)
 - [docker-compose/watchtower/docker-compose.yml](docker-compose/watchtower/docker-compose.yml)
 
 Additional repo content includes dotfiles, editor config, and utility scripts, but the homelab deployment path is centered on the compose files above.
@@ -93,6 +94,7 @@ Start here for the detailed rebuild docs:
 - [docs/stacks/immich.md](docs/stacks/immich.md)
 - [docs/stacks/nextcloud-aio.md](docs/stacks/nextcloud-aio.md)
 - [docs/stacks/openclaw.md](docs/stacks/openclaw.md)
+- [docs/stacks/actual-budget.md](docs/stacks/actual-budget.md)
 - [docs/stacks/watchtower.md](docs/stacks/watchtower.md)
 
 ## Repository Layout

--- a/docker-compose/actual-budget/docker-compose.yml
+++ b/docker-compose/actual-budget/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  actual-budget:
+    image: actualbudget/actual-server:latest-alpine
+    container_name: actual-budget
+    restart: unless-stopped
+    environment:
+      TZ: "Asia/Kolkata"
+    volumes:
+      - /mnt/ssd/docker-volumes/actual-budget/data:/data
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:5006/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+networks:
+  proxy:
+    external: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Use the docs in this order for a full rebuild:
 - [stacks/immich.md](stacks/immich.md)
 - [stacks/nextcloud-aio.md](stacks/nextcloud-aio.md)
 - [stacks/openclaw.md](stacks/openclaw.md)
+- [stacks/actual-budget.md](stacks/actual-budget.md)
 - [stacks/watchtower.md](stacks/watchtower.md)
 
 ## Documentation Conventions

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -70,6 +70,13 @@ The placeholders are documentation variables only. They are not automatically ex
 | `${OPENCLAW_HOSTNAME}` | Private hostname for the OpenClaw gateway | `openclaw.homelab.ansh-info.com` |
 | `${OPENCLAW_GATEWAY_PORT}` | Internal Gateway port served by OpenClaw | `18789` |
 
+## Actual Budget Variables
+
+| Variable | Meaning | Current Example |
+| --- | --- | --- |
+| `${ACTUAL_DATA_ROOT}` | Host path for Actual Budget persistent data | `/mnt/ssd/docker-volumes/actual-budget/data` |
+| `${ACTUAL_HOSTNAME}` | Private hostname for Actual Budget | `actual.homelab.ansh-info.com` |
+
 ## Notes
 
 - When multiple docs mention the same variable, prefer using the definitions in this file rather than inventing a new variant.

--- a/docs/stacks/actual-budget.md
+++ b/docs/stacks/actual-budget.md
@@ -1,0 +1,102 @@
+# Actual Budget
+
+Actual Budget is a local-first personal finance tool with optional sync. It provides envelope budgeting, bank syncing, and reporting - all self-hosted.
+
+## Access
+
+- Private hostname: `actual.${DOMAIN_ROOT}`
+- Internal upstream: `actual-budget:5006`
+- Scheme: `http`
+
+## Compose Location
+
+```text
+docker-compose/actual-budget/docker-compose.yml
+```
+
+## Storage
+
+| Path | Purpose |
+| --- | --- |
+| `/mnt/ssd/docker-volumes/actual-budget/data` | Persistent data (server-files, user-files, SQLite databases) |
+
+## NPM Proxy Host
+
+| Field | Value |
+| --- | --- |
+| Domain | `actual.homelab.ansh-info.com` |
+| Scheme | `http` |
+| Forward Hostname | `actual-budget` |
+| Forward Port | `5006` |
+| Cache Assets | enabled |
+| Block Common Exploits | enabled |
+| Websockets Support | enabled |
+| Force SSL | enabled |
+| HTTP/2 Support | enabled |
+| HSTS Enabled | enabled |
+| HSTS Sub-domains | enabled |
+| SSL Certificate | `*.homelab.ansh-info.com` wildcard |
+
+## Deployment
+
+Deploy via Portainer using the compose file. No additional environment file is needed.
+
+### Host preparation
+
+```bash
+sudo mkdir -p /mnt/ssd/docker-volumes/actual-budget/data
+```
+
+### Portainer deployment
+
+1. Create a new stack named `actual-budget`
+2. Paste the compose file contents or point to the git repo path
+3. Deploy
+
+### CLI fallback
+
+```bash
+cd docker-compose/actual-budget
+docker compose up -d
+```
+
+## Verification
+
+```bash
+# Container health
+docker ps --filter name=actual-budget
+
+# Network membership
+docker network inspect proxy | grep actual-budget
+
+# DNS resolution (from tailnet client)
+dig +short actual.${DOMAIN_ROOT} @${TAILSCALE_IP}
+
+# Proxy routing
+curl -vk --resolve actual.${DOMAIN_ROOT}:443:${TAILSCALE_IP} https://actual.${DOMAIN_ROOT}/
+```
+
+## Updates
+
+Watchtower will auto-update this container since it uses `latest-alpine`. For manual updates:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+## Backup
+
+Back up the data directory:
+
+```bash
+/mnt/ssd/docker-volumes/actual-budget/data
+```
+
+This contains all budget files and user data. The SQLite databases inside are the primary state - no external database is needed.
+
+## Related Docs
+
+- [NETWORKING.md](../NETWORKING.md)
+- [VARIABLES.md](../VARIABLES.md)
+- [OPERATIONS.md](../OPERATIONS.md)
+- [nginx-proxy-manager.md](nginx-proxy-manager.md)


### PR DESCRIPTION
## Summary

- Adds a new `actual-budget` Docker Compose stack for self-hosted personal finance management
- Actual Budget provides envelope budgeting, transaction tracking, bank sync, and reporting with charts - a self-hosted YNAB alternative
- Uses `actualbudget/actual-server:latest-alpine` on the shared `proxy` network with persistent storage at `/mnt/ssd/docker-volumes/actual-budget/data`
- Accessible at `actual.homelab.ansh-info.com` via NPM (no host port binding)

## Changes

| Commit | Scope |
|--------|-------|
| `feat: add actual-budget stack` | Compose file with healthcheck, proxy network, alpine image |
| `docs: add stack guide` | Full deployment, NPM config, verification, and backup docs |
| `docs: add variables` | `ACTUAL_DATA_ROOT` and `ACTUAL_HOSTNAME` in VARIABLES.md |
| `docs: update READMEs` | Links in README.md and docs/README.md |
| `docs: update CLAUDE.md and AGENTS.md` | Stack count and list |
| `ci: add to validation matrix` | CI validates compose config on push |

## NPM Proxy Host Config

| Field | Value |
|-------|-------|
| Domain | `actual.homelab.ansh-info.com` |
| Scheme | `http` |
| Forward Hostname | `actual-budget` |
| Forward Port | `5006` |
| SSL Certificate | `*.homelab.ansh-info.com` wildcard |

## Test plan

- [x] `docker compose config` validates cleanly
- [x] Container starts and healthcheck passes
- [x] Accessible via `actual.homelab.ansh-info.com` through NPM
- [x] Bootstrap screen appears on first visit
- [ ] CI validation passes for the new matrix entry