### PR TITLE
feat: add Uptime Kuma stack for service monitoring

### DIFF
--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -93,6 +93,17 @@ jobs:
             db_database_name: placeholder
             pihole_password: placeholder
             tailscale_ip: 127.0.0.1
+          - name: uptime-kuma
+            path: docker-compose/uptime-kuma
+            gpu: false
+            host_mounts: true
+            upload_location: /tmp/uploads-unused
+            db_data_location: /tmp/db-unused
+            db_password: placeholder
+            db_username: placeholder
+            db_database_name: placeholder
+            pihole_password: placeholder
+            tailscale_ip: 127.0.0.1
           - name: watchtower
             path: docker-compose/watchtower
             gpu: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Current stack layout:
 - `docker-compose/nextcloud-aio`
 - `docker-compose/openclaw`
 - `docker-compose/actual-budget`
+- `docker-compose/uptime-kuma`
 - `docker-compose/watchtower`
 
 If a new stack is added, place it under:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ CI runs `docker compose config` for every stack on all pushes. The immich stack 
 
 ## Stack Layout
 
-Eight compose stacks under `docker-compose/`:
+Nine compose stacks under `docker-compose/`:
 
 - `pihole` - DNS authority (port 53 on host)
 - `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
@@ -56,6 +56,7 @@ Eight compose stacks under `docker-compose/`:
 - `nextcloud-aio` - Cloud storage (two NPM hosts: admin + app)
 - `openclaw` - AI assistant gateway (stateful, manual updates only)
 - `actual-budget` - Personal finance and envelope budgeting
+- `uptime-kuma` - Service uptime monitoring and alerting
 - `watchtower` - Auto-updates for other containers
 
 ## Dotfiles

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The main service definitions live under [docker-compose](docker-compose):
 - [docker-compose/nextcloud-aio/docker-compose.yml](docker-compose/nextcloud-aio/docker-compose.yml)
 - [docker-compose/openclaw/docker-compose.yml](docker-compose/openclaw/docker-compose.yml)
 - [docker-compose/actual-budget/docker-compose.yml](docker-compose/actual-budget/docker-compose.yml)
+- [docker-compose/uptime-kuma/docker-compose.yml](docker-compose/uptime-kuma/docker-compose.yml)
 - [docker-compose/watchtower/docker-compose.yml](docker-compose/watchtower/docker-compose.yml)
 
 Additional repo content includes dotfiles, editor config, and utility scripts, but the homelab deployment path is centered on the compose files above.
@@ -95,6 +96,7 @@ Start here for the detailed rebuild docs:
 - [docs/stacks/nextcloud-aio.md](docs/stacks/nextcloud-aio.md)
 - [docs/stacks/openclaw.md](docs/stacks/openclaw.md)
 - [docs/stacks/actual-budget.md](docs/stacks/actual-budget.md)
+- [docs/stacks/uptime-kuma.md](docs/stacks/uptime-kuma.md)
 - [docs/stacks/watchtower.md](docs/stacks/watchtower.md)
 
 ## Repository Layout

--- a/docker-compose/uptime-kuma/docker-compose.yml
+++ b/docker-compose/uptime-kuma/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  uptime-kuma:
+    image: louislam/uptime-kuma:2
+    container_name: uptime-kuma
+    restart: unless-stopped
+    environment:
+      TZ: "Asia/Kolkata"
+    volumes:
+      - /mnt/ssd/docker-volumes/uptime-kuma/data:/app/data
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "extra/healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+networks:
+  proxy:
+    external: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Use the docs in this order for a full rebuild:
 - [stacks/nextcloud-aio.md](stacks/nextcloud-aio.md)
 - [stacks/openclaw.md](stacks/openclaw.md)
 - [stacks/actual-budget.md](stacks/actual-budget.md)
+- [stacks/uptime-kuma.md](stacks/uptime-kuma.md)
 - [stacks/watchtower.md](stacks/watchtower.md)
 
 ## Documentation Conventions

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -70,6 +70,13 @@ The placeholders are documentation variables only. They are not automatically ex
 | `${OPENCLAW_HOSTNAME}` | Private hostname for the OpenClaw gateway | `openclaw.homelab.ansh-info.com` |
 | `${OPENCLAW_GATEWAY_PORT}` | Internal Gateway port served by OpenClaw | `18789` |
 
+## Uptime Kuma Variables
+
+| Variable | Meaning | Current Example |
+| --- | --- | --- |
+| `${UPTIME_KUMA_DATA_ROOT}` | Host path for Uptime Kuma persistent data | `/mnt/ssd/docker-volumes/uptime-kuma/data` |
+| `${UPTIME_KUMA_HOSTNAME}` | Private hostname for Uptime Kuma | `status.homelab.ansh-info.com` |
+
 ## Actual Budget Variables
 
 | Variable | Meaning | Current Example |

--- a/docs/stacks/uptime-kuma.md
+++ b/docs/stacks/uptime-kuma.md
@@ -1,0 +1,121 @@
+# Uptime Kuma
+
+Uptime Kuma is a self-hosted monitoring tool that tracks service uptime and sends alerts when endpoints go down. Supports HTTP, TCP, DNS, Docker, and ping monitors with notification channels including Discord, email, Slack, and Telegram.
+
+## Access
+
+- Private hostname: `status.${DOMAIN_ROOT}`
+- Internal upstream: `uptime-kuma:3001`
+- Scheme: `http`
+
+## Compose Location
+
+```text
+docker-compose/uptime-kuma/docker-compose.yml
+```
+
+## Storage
+
+| Path | Purpose |
+| --- | --- |
+| `/mnt/ssd/docker-volumes/uptime-kuma/data` | Persistent data (SQLite database, monitor configs, notification settings) |
+
+Important: the data directory must be on a local filesystem. NFS or network-backed storage risks SQLite corruption due to file locking issues.
+
+## NPM Proxy Host
+
+| Field | Value |
+| --- | --- |
+| Domain | `status.homelab.ansh-info.com` |
+| Scheme | `http` |
+| Forward Hostname | `uptime-kuma` |
+| Forward Port | `3001` |
+| Cache Assets | enabled |
+| Block Common Exploits | enabled |
+| Websockets Support | enabled (required - app is WebSocket-based) |
+| Force SSL | enabled |
+| HTTP/2 Support | enabled |
+| HSTS Enabled | enabled |
+| HSTS Sub-domains | enabled |
+| SSL Certificate | `*.homelab.ansh-info.com` wildcard |
+
+Websockets Support is critical for Uptime Kuma. The app uses WebSocket connections for real-time status updates. Without this toggle, the UI will fail to load or show stale data.
+
+## Deployment
+
+Deploy via Portainer using the compose file. No additional environment file is needed.
+
+### Host preparation
+
+```bash
+sudo mkdir -p /mnt/ssd/docker-volumes/uptime-kuma/data
+```
+
+### Portainer deployment
+
+1. Create a new stack named `uptime-kuma`
+2. Paste the compose file contents or point to the git repo path
+3. Deploy
+
+### CLI fallback
+
+```bash
+cd docker-compose/uptime-kuma
+docker compose up -d
+```
+
+## Post-Deployment Setup
+
+1. Visit `status.${DOMAIN_ROOT}` after deployment
+2. Create an admin account (first visit only)
+3. Add monitors for each homelab service:
+   - Pi-hole: HTTP `http://pihole:80/admin/`
+   - NPM: HTTP `http://nginx-proxy-manager:81`
+   - Jellyfin: HTTP `http://jellyfin:8096`
+   - Immich: HTTP `http://immich_server:2283`
+   - Actual Budget: HTTP `http://actual-budget:5006`
+   - OpenClaw: HTTP `http://openclaw-gateway:18789/healthz`
+4. Configure notification channels (Discord webhook, email, etc.)
+
+All monitors use internal container hostnames since Uptime Kuma is on the same `proxy` network.
+
+## Verification
+
+```bash
+# Container health
+docker ps --filter name=uptime-kuma
+
+# Network membership
+docker network inspect proxy | grep uptime-kuma
+
+# DNS resolution (from tailnet client)
+dig +short status.${DOMAIN_ROOT} @${TAILSCALE_IP}
+
+# Proxy routing
+curl -vk --resolve status.${DOMAIN_ROOT}:443:${TAILSCALE_IP} https://status.${DOMAIN_ROOT}/
+```
+
+## Updates
+
+Watchtower will auto-update this container. For manual updates:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+## Backup
+
+Back up the data directory:
+
+```bash
+/mnt/ssd/docker-volumes/uptime-kuma/data
+```
+
+Contains the SQLite database with all monitor configurations, history, and notification settings.
+
+## Related Docs
+
+- [NETWORKING.md](../NETWORKING.md)
+- [VARIABLES.md](../VARIABLES.md)
+- [OPERATIONS.md](../OPERATIONS.md)
+- [nginx-proxy-manager.md](nginx-proxy-manager.md)


### PR DESCRIPTION
## Summary

- Adds a new `uptime-kuma` Docker Compose stack for self-hosted service uptime monitoring
- WebSocket-based real-time status dashboard with alerting (Discord, email, Slack, Telegram)
- Uses `louislam/uptime-kuma:2` on the shared `proxy` network with persistent storage at `/mnt/ssd/docker-volumes/uptime-kuma/data`
- Accessible at `status.homelab.ansh-info.com` via NPM (websockets required)

## Changes

| Commit | Scope |
|--------|-------|
| `feat: add uptime-kuma stack` | Compose file with built-in healthcheck, proxy network |
| `docs: add stack guide` | Full deployment, NPM config, post-deploy monitor setup, backup docs |
| `docs: add variables` | `UPTIME_KUMA_DATA_ROOT` and `UPTIME_KUMA_HOSTNAME` in VARIABLES.md |
| `docs: update READMEs` | Links in README.md and docs/README.md |
| `docs: update CLAUDE.md and AGENTS.md` | Stack count and list |
| `ci: add to validation matrix` | CI validates compose config on push |

## NPM Proxy Host Config

| Field | Value |
|-------|-------|
| Domain | `status.homelab.ansh-info.com` |
| Scheme | `http` |
| Forward Hostname | `uptime-kuma` |
| Forward Port | `3001` |
| Websockets Support | enabled (required) |
| SSL Certificate | `*.homelab.ansh-info.com` wildcard |

## Test plan

- [x] `docker compose config` validates cleanly
- [ ] Container starts and healthcheck passes
- [ ] Accessible via `status.homelab.ansh-info.com` through NPM
- [ ] Admin account creation on first visit
- [ ] Can add monitors for existing homelab services
- [ ] CI validation passes for the new matrix entry