### PR TITLE
feat: add Vaultwarden stack for self-hosted password management

### DIFF
--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -93,6 +93,17 @@ jobs:
             db_database_name: placeholder
             pihole_password: placeholder
             tailscale_ip: 127.0.0.1
+          - name: vaultwarden
+            path: docker-compose/vaultwarden
+            gpu: false
+            host_mounts: true
+            upload_location: /tmp/uploads-unused
+            db_data_location: /tmp/db-unused
+            db_password: placeholder
+            db_username: placeholder
+            db_database_name: placeholder
+            pihole_password: placeholder
+            tailscale_ip: 127.0.0.1
           - name: watchtower
             path: docker-compose/watchtower
             gpu: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Current stack layout:
 - `docker-compose/nextcloud-aio`
 - `docker-compose/openclaw`
 - `docker-compose/actual-budget`
+- `docker-compose/vaultwarden`
 - `docker-compose/watchtower`
 
 If a new stack is added, place it under:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ CI runs `docker compose config` for every stack on all pushes. The immich stack 
 
 ## Stack Layout
 
-Eight compose stacks under `docker-compose/`:
+Nine compose stacks under `docker-compose/`:
 
 - `pihole` - DNS authority (port 53 on host)
 - `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
@@ -56,6 +56,7 @@ Eight compose stacks under `docker-compose/`:
 - `nextcloud-aio` - Cloud storage (two NPM hosts: admin + app)
 - `openclaw` - AI assistant gateway (stateful, manual updates only)
 - `actual-budget` - Personal finance and envelope budgeting
+- `vaultwarden` - Self-hosted Bitwarden password manager
 - `watchtower` - Auto-updates for other containers
 
 ## Dotfiles

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The main service definitions live under [docker-compose](docker-compose):
 - [docker-compose/nextcloud-aio/docker-compose.yml](docker-compose/nextcloud-aio/docker-compose.yml)
 - [docker-compose/openclaw/docker-compose.yml](docker-compose/openclaw/docker-compose.yml)
 - [docker-compose/actual-budget/docker-compose.yml](docker-compose/actual-budget/docker-compose.yml)
+- [docker-compose/vaultwarden/docker-compose.yml](docker-compose/vaultwarden/docker-compose.yml)
 - [docker-compose/watchtower/docker-compose.yml](docker-compose/watchtower/docker-compose.yml)
 
 Additional repo content includes dotfiles, editor config, and utility scripts, but the homelab deployment path is centered on the compose files above.
@@ -95,6 +96,7 @@ Start here for the detailed rebuild docs:
 - [docs/stacks/nextcloud-aio.md](docs/stacks/nextcloud-aio.md)
 - [docs/stacks/openclaw.md](docs/stacks/openclaw.md)
 - [docs/stacks/actual-budget.md](docs/stacks/actual-budget.md)
+- [docs/stacks/vaultwarden.md](docs/stacks/vaultwarden.md)
 - [docs/stacks/watchtower.md](docs/stacks/watchtower.md)
 
 ## Repository Layout

--- a/docker-compose/vaultwarden/docker-compose.yml
+++ b/docker-compose/vaultwarden/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  vaultwarden:
+    image: vaultwarden/server:latest
+    container_name: vaultwarden
+    restart: unless-stopped
+    environment:
+      TZ: "Asia/Kolkata"
+      DOMAIN: "https://vault.homelab.ansh-info.com"
+      SIGNUPS_ALLOWED: "false"
+    volumes:
+      - /mnt/ssd/docker-volumes/vaultwarden/data:/data
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:80/alive"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+networks:
+  proxy:
+    external: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Use the docs in this order for a full rebuild:
 - [stacks/nextcloud-aio.md](stacks/nextcloud-aio.md)
 - [stacks/openclaw.md](stacks/openclaw.md)
 - [stacks/actual-budget.md](stacks/actual-budget.md)
+- [stacks/vaultwarden.md](stacks/vaultwarden.md)
 - [stacks/watchtower.md](stacks/watchtower.md)
 
 ## Documentation Conventions

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -70,6 +70,13 @@ The placeholders are documentation variables only. They are not automatically ex
 | `${OPENCLAW_HOSTNAME}` | Private hostname for the OpenClaw gateway | `openclaw.homelab.ansh-info.com` |
 | `${OPENCLAW_GATEWAY_PORT}` | Internal Gateway port served by OpenClaw | `18789` |
 
+## Vaultwarden Variables
+
+| Variable | Meaning | Current Example |
+| --- | --- | --- |
+| `${VAULTWARDEN_DATA_ROOT}` | Host path for Vaultwarden persistent data | `/mnt/ssd/docker-volumes/vaultwarden/data` |
+| `${VAULTWARDEN_HOSTNAME}` | Private hostname for Vaultwarden | `vault.homelab.ansh-info.com` |
+
 ## Actual Budget Variables
 
 | Variable | Meaning | Current Example |

--- a/docs/stacks/vaultwarden.md
+++ b/docs/stacks/vaultwarden.md
@@ -1,0 +1,133 @@
+# Vaultwarden
+
+Vaultwarden is a lightweight self-hosted Bitwarden-compatible password manager. Supports all Bitwarden clients (browser extensions, mobile apps, desktop apps) with a minimal resource footprint.
+
+## Access
+
+- Private hostname: `vault.${DOMAIN_ROOT}`
+- Internal upstream: `vaultwarden:80`
+- Scheme: `http`
+
+## Compose Location
+
+```text
+docker-compose/vaultwarden/docker-compose.yml
+```
+
+## Storage
+
+| Path | Purpose |
+| --- | --- |
+| `/mnt/ssd/docker-volumes/vaultwarden/data` | Persistent data (encrypted vault SQLite database, attachments, RSA keys, icon cache) |
+
+## NPM Proxy Host
+
+| Field | Value |
+| --- | --- |
+| Domain | `vault.homelab.ansh-info.com` |
+| Scheme | `http` |
+| Forward Hostname | `vaultwarden` |
+| Forward Port | `80` |
+| Cache Assets | enabled |
+| Block Common Exploits | enabled |
+| Websockets Support | enabled |
+| Force SSL | enabled |
+| HTTP/2 Support | enabled |
+| HSTS Enabled | enabled |
+| HSTS Sub-domains | enabled |
+| SSL Certificate | `*.homelab.ansh-info.com` wildcard |
+
+## Environment Variables
+
+| Variable | Value | Purpose |
+| --- | --- | --- |
+| `DOMAIN` | `https://vault.homelab.ansh-info.com` | Required for attachment URLs and WebSocket notifications |
+| `SIGNUPS_ALLOWED` | `false` | Disable public registration after initial account creation |
+
+## Deployment
+
+Deploy via Portainer using the compose file. No additional environment file is needed.
+
+### Host preparation
+
+```bash
+sudo mkdir -p /mnt/ssd/docker-volumes/vaultwarden/data
+```
+
+### First deployment (signups enabled)
+
+For the initial deployment, temporarily set `SIGNUPS_ALLOWED: "true"` in the compose file or Portainer env override. Create your account, then set it back to `"false"` and redeploy.
+
+### Portainer deployment
+
+1. Create a new stack named `vaultwarden`
+2. Paste the compose file contents or point to the git repo path
+3. Deploy
+4. Create your account at `vault.${DOMAIN_ROOT}`
+5. Redeploy with `SIGNUPS_ALLOWED: "false"` to lock registration
+
+### CLI fallback
+
+```bash
+cd docker-compose/vaultwarden
+docker compose up -d
+```
+
+## Client Setup
+
+After deployment, connect Bitwarden clients:
+
+1. Open any Bitwarden client (browser extension, mobile, desktop)
+2. Before logging in, tap the gear icon or "Self-hosted"
+3. Set server URL to `https://vault.homelab.ansh-info.com`
+4. Log in with the account you created
+
+Works with all official Bitwarden clients and third-party clients like Goldwarden.
+
+## Verification
+
+```bash
+# Container health
+docker ps --filter name=vaultwarden
+
+# Network membership
+docker network inspect proxy | grep vaultwarden
+
+# DNS resolution (from tailnet client)
+dig +short vault.${DOMAIN_ROOT} @${TAILSCALE_IP}
+
+# Proxy routing
+curl -vk --resolve vault.${DOMAIN_ROOT}:443:${TAILSCALE_IP} https://vault.${DOMAIN_ROOT}/
+```
+
+## Updates
+
+Watchtower will auto-update this container. For manual updates:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+## Backup
+
+Back up the data directory:
+
+```bash
+/mnt/ssd/docker-volumes/vaultwarden/data
+```
+
+Contains the encrypted SQLite database, RSA keys, and attachments. This is the single most critical backup target in the homelab - losing this means losing all passwords.
+
+## Security Notes
+
+- `SIGNUPS_ALLOWED` is `false` by default - only the initial admin can create accounts
+- All vault data is encrypted client-side before reaching the server
+- The `DOMAIN` variable must match the actual access URL for WebSocket push notifications to work
+- Access is restricted to the tailnet via the standard Tailscale + Pi-hole + NPM path
+
+## Related Docs
+
+- [NETWORKING.md](../NETWORKING.md)
+- [VARIABLES.md](../VARIABLES.md)
+- [OPERATIONS.md](../OPERATIONS.md)
+- [nginx-proxy-manager.md](nginx-proxy-manager.md)


### PR DESCRIPTION
## Summary

- Adds a new `vaultwarden` Docker Compose stack for self-hosted Bitwarden-compatible password management
- Uses `vaultwarden/server:latest` on the shared `proxy` network with persistent storage at `/mnt/ssd/docker-volumes/vaultwarden/data`
- Accessible at `vault.homelab.ansh-info.com` via NPM
- Signups disabled by default - enable temporarily for initial account creation, then lock

## Changes

| Commit | Scope |
|--------|-------|
| `feat: add vaultwarden stack` | Compose file with healthcheck, proxy network, signups disabled |
| `docs: add stack guide` | Deployment, first-run signup flow, client setup, security notes |
| `docs: add variables` | `VAULTWARDEN_DATA_ROOT` and `VAULTWARDEN_HOSTNAME` in VARIABLES.md |
| `docs: update READMEs` | Links in README.md and docs/README.md |
| `docs: update CLAUDE.md and AGENTS.md` | Stack count and list |
| `ci: add to validation matrix` | CI validates compose config on push |

## NPM Proxy Host Config

| Field | Value |
|-------|-------|
| Domain | `vault.homelab.ansh-info.com` |
| Scheme | `http` |
| Forward Hostname | `vaultwarden` |
| Forward Port | `80` |
| Websockets Support | enabled |
| SSL Certificate | `*.homelab.ansh-info.com` wildcard |

## First-Run Steps

1. Temporarily set `SIGNUPS_ALLOWED: "true"` in Portainer env
2. Deploy and create your account at `vault.homelab.ansh-info.com`
3. Set `SIGNUPS_ALLOWED: "false"` and redeploy to lock registration
4. Connect Bitwarden clients with server URL `https://vault.homelab.ansh-info.com`

## Test plan

- [x] `docker compose config` validates cleanly
- [ ] Container starts and healthcheck passes
- [ ] Accessible via `vault.homelab.ansh-info.com` through NPM
- [ ] Account creation works with signups enabled
- [ ] Bitwarden client connects successfully
- [ ] CI validation passes for the new matrix entry