### PR TITLE
feat: add Duplicati stack for encrypted backups

### DIFF
--- a/.github/workflows/docker-compose-validate.yml
+++ b/.github/workflows/docker-compose-validate.yml
@@ -93,6 +93,17 @@ jobs:
             db_database_name: placeholder
             pihole_password: placeholder
             tailscale_ip: 127.0.0.1
+          - name: duplicati
+            path: docker-compose/duplicati
+            gpu: false
+            host_mounts: true
+            upload_location: /tmp/uploads-unused
+            db_data_location: /tmp/db-unused
+            db_password: placeholder
+            db_username: placeholder
+            db_database_name: placeholder
+            pihole_password: placeholder
+            tailscale_ip: 127.0.0.1
           - name: watchtower
             path: docker-compose/watchtower
             gpu: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ Current stack layout:
 - `docker-compose/nextcloud-aio`
 - `docker-compose/openclaw`
 - `docker-compose/actual-budget`
+- `docker-compose/duplicati`
 - `docker-compose/watchtower`
 
 If a new stack is added, place it under:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ CI runs `docker compose config` for every stack on all pushes. The immich stack 
 
 ## Stack Layout
 
-Eight compose stacks under `docker-compose/`:
+Nine compose stacks under `docker-compose/`:
 
 - `pihole` - DNS authority (port 53 on host)
 - `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
@@ -56,6 +56,7 @@ Eight compose stacks under `docker-compose/`:
 - `nextcloud-aio` - Cloud storage (two NPM hosts: admin + app)
 - `openclaw` - AI assistant gateway (stateful, manual updates only)
 - `actual-budget` - Personal finance and envelope budgeting
+- `duplicati` - Encrypted backups of docker-volumes to HDD
 - `watchtower` - Auto-updates for other containers
 
 ## Dotfiles

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The main service definitions live under [docker-compose](docker-compose):
 - [docker-compose/nextcloud-aio/docker-compose.yml](docker-compose/nextcloud-aio/docker-compose.yml)
 - [docker-compose/openclaw/docker-compose.yml](docker-compose/openclaw/docker-compose.yml)
 - [docker-compose/actual-budget/docker-compose.yml](docker-compose/actual-budget/docker-compose.yml)
+- [docker-compose/duplicati/docker-compose.yml](docker-compose/duplicati/docker-compose.yml)
 - [docker-compose/watchtower/docker-compose.yml](docker-compose/watchtower/docker-compose.yml)
 
 Additional repo content includes dotfiles, editor config, and utility scripts, but the homelab deployment path is centered on the compose files above.
@@ -95,6 +96,7 @@ Start here for the detailed rebuild docs:
 - [docs/stacks/nextcloud-aio.md](docs/stacks/nextcloud-aio.md)
 - [docs/stacks/openclaw.md](docs/stacks/openclaw.md)
 - [docs/stacks/actual-budget.md](docs/stacks/actual-budget.md)
+- [docs/stacks/duplicati.md](docs/stacks/duplicati.md)
 - [docs/stacks/watchtower.md](docs/stacks/watchtower.md)
 
 ## Repository Layout

--- a/docker-compose/duplicati/docker-compose.yml
+++ b/docker-compose/duplicati/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  duplicati:
+    image: linuxserver/duplicati:latest
+    container_name: duplicati
+    restart: unless-stopped
+    environment:
+      TZ: "Asia/Kolkata"
+      PUID: "0"
+      PGID: "0"
+    volumes:
+      - /mnt/ssd/docker-volumes/duplicati/config:/config
+      - /mnt/backup:/backups
+      - /mnt/ssd/docker-volumes:/source:ro
+    networks:
+      - proxy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8200/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+networks:
+  proxy:
+    external: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Use the docs in this order for a full rebuild:
 - [stacks/nextcloud-aio.md](stacks/nextcloud-aio.md)
 - [stacks/openclaw.md](stacks/openclaw.md)
 - [stacks/actual-budget.md](stacks/actual-budget.md)
+- [stacks/duplicati.md](stacks/duplicati.md)
 - [stacks/watchtower.md](stacks/watchtower.md)
 
 ## Documentation Conventions

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -70,6 +70,14 @@ The placeholders are documentation variables only. They are not automatically ex
 | `${OPENCLAW_HOSTNAME}` | Private hostname for the OpenClaw gateway | `openclaw.homelab.ansh-info.com` |
 | `${OPENCLAW_GATEWAY_PORT}` | Internal Gateway port served by OpenClaw | `18789` |
 
+## Duplicati Variables
+
+| Variable | Meaning | Current Example |
+| --- | --- | --- |
+| `${DUPLICATI_CONFIG_ROOT}` | Host path for Duplicati configuration | `/mnt/ssd/docker-volumes/duplicati/config` |
+| `${DUPLICATI_HOSTNAME}` | Private hostname for Duplicati | `backup.homelab.ansh-info.com` |
+| `${BACKUP_ROOT}` | Mount point for backup destination HDD | `/mnt/backup` |
+
 ## Actual Budget Variables
 
 | Variable | Meaning | Current Example |

--- a/docs/stacks/duplicati.md
+++ b/docs/stacks/duplicati.md
@@ -1,0 +1,197 @@
+# Duplicati
+
+Duplicati is a self-hosted backup tool with a web UI for scheduling encrypted, deduplicated backups to local or remote storage.
+
+## Access
+
+- Private hostname: `backup.${DOMAIN_ROOT}`
+- Internal upstream: `duplicati:8200`
+- Scheme: `http`
+
+## Compose Location
+
+```text
+docker-compose/duplicati/docker-compose.yml
+```
+
+## Storage
+
+| Path | Mount inside container | Purpose |
+| --- | --- | --- |
+| `/mnt/ssd/docker-volumes/duplicati/config` | `/config` | Duplicati configuration database and job definitions |
+| `/mnt/backup` | `/backups` | Backup destination (HDD) |
+| `/mnt/ssd/docker-volumes` | `/source` (read-only) | Source data to back up |
+
+The source mount is read-only to prevent Duplicati from accidentally modifying service data.
+
+## NPM Proxy Host
+
+| Field | Value |
+| --- | --- |
+| Domain | `backup.homelab.ansh-info.com` |
+| Scheme | `http` |
+| Forward Hostname | `duplicati` |
+| Forward Port | `8200` |
+| Cache Assets | enabled |
+| Block Common Exploits | enabled |
+| Websockets Support | enabled |
+| Force SSL | enabled |
+| HTTP/2 Support | enabled |
+| HSTS Enabled | enabled |
+| HSTS Sub-domains | enabled |
+| SSL Certificate | `*.homelab.ansh-info.com` wildcard |
+
+## Environment Variables
+
+| Variable | Value | Purpose |
+| --- | --- | --- |
+| `PUID` | `0` | Run as root to read all service volumes regardless of ownership |
+| `PGID` | `0` | Run as root group |
+| `TZ` | `Asia/Kolkata` | Timezone for scheduling |
+
+Running as root is intentional here - Duplicati needs to read files owned by various service users (Nextcloud uses 33:33, others use different UIDs). The source mount is read-only as a safety net.
+
+## Deployment
+
+### Prerequisites
+
+1. Backup HDD installed and mounted at `/mnt/backup`
+2. Entry in `/etc/fstab` with `nofail` option (prevents boot failure if HDD is disconnected)
+
+### Host preparation
+
+```bash
+# Format the backup HDD (verify device name first with lsblk!)
+sudo mkfs.ext4 /dev/sdX1
+
+# Create mount point
+sudo mkdir -p /mnt/backup
+
+# Get UUID
+sudo blkid /dev/sdX1
+
+# Add to /etc/fstab
+# UUID=<your-uuid>  /mnt/backup  ext4  defaults,nofail  0  2
+
+# Mount and create config directory
+sudo mount -a
+sudo mkdir -p /mnt/ssd/docker-volumes/duplicati/config
+```
+
+### Portainer deployment
+
+1. Create a new stack named `duplicati`
+2. Paste the compose file contents or point to the git repo path
+3. Deploy
+
+### CLI fallback
+
+```bash
+cd docker-compose/duplicati
+docker compose up -d
+```
+
+## Post-Deployment Setup
+
+### Recommended backup jobs
+
+Create these backup jobs in the Duplicati web UI:
+
+#### Job 1: Critical (daily)
+
+- Source: `/source/vaultwarden`, `/source/pihole`, `/source/nginx-proxy-manager`, `/source/actual-budget`, `/source/uptime-kuma`
+- Destination: `/backups/daily-critical`
+- Schedule: Daily at 03:00
+- Retention: Keep 7 daily + 4 weekly versions
+- Encryption: AES-256 (set a passphrase you will remember)
+
+#### Job 2: Media configs (weekly)
+
+- Source: `/source/arr/radarr/config`, `/source/arr/sonarr/config`, `/source/arr/prowlarr/config`, `/source/arr/bazarr/config`, `/source/arr/qbittorrent`
+- Destination: `/backups/weekly-configs`
+- Schedule: Weekly Sunday 04:00
+- Retention: Keep 4 weekly versions
+- Encryption: AES-256
+
+#### Job 3: Photos (weekly)
+
+- Source: `/source/immich`
+- Destination: `/backups/weekly-photos`
+- Schedule: Weekly Sunday 05:00
+- Retention: Keep 4 weekly versions
+- Encryption: AES-256
+
+#### Job 4: Cloud storage (weekly)
+
+- Source: `/source/nextcloud`
+- Destination: `/backups/weekly-nextcloud`
+- Schedule: Weekly Sunday 06:00
+- Retention: Keep 4 weekly versions
+- Encryption: AES-256
+
+### Encryption passphrase
+
+Choose a strong passphrase for backup encryption. Store it in Vaultwarden. Without this passphrase, backups cannot be restored.
+
+## Verification
+
+```bash
+# Container health
+docker ps --filter name=duplicati
+
+# Network membership
+docker network inspect proxy | grep duplicati
+
+# DNS resolution (from tailnet client)
+dig +short backup.${DOMAIN_ROOT} @${TAILSCALE_IP}
+
+# Proxy routing
+curl -vk --resolve backup.${DOMAIN_ROOT}:443:${TAILSCALE_IP} https://backup.${DOMAIN_ROOT}/
+
+# Backup destination accessible
+docker exec duplicati ls /backups
+docker exec duplicati ls /source
+```
+
+## Updates
+
+Watchtower will auto-update this container. For manual updates:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+## Restore Process
+
+1. Open Duplicati UI at `backup.${DOMAIN_ROOT}`
+2. Select the backup job to restore from
+3. Browse files and select what to restore
+4. Choose restore location (original path or alternate)
+5. Duplicati decrypts and reassembles the files
+
+For disaster recovery (Duplicati itself lost):
+1. Redeploy the Duplicati container
+2. Point it at `/backups` destination
+3. Use "Restore from configuration" to reimport job definitions
+4. Or manually browse the backup files in the UI
+
+## Backup Priorities
+
+| Priority | Data | Why |
+| --- | --- | --- |
+| Critical | Vaultwarden | All passwords - unrecoverable without backup |
+| Critical | Pi-hole config | DNS authority - services unreachable without it |
+| Critical | NPM certs and config | TLS and routing - breaks all hostname access |
+| High | Actual Budget | Financial history |
+| High | Uptime Kuma | Monitor configurations and history |
+| Medium | Immich | Photos (large, may take time) |
+| Medium | Nextcloud | Cloud files |
+| Medium | Arr configs | Service settings (media itself is re-downloadable) |
+| Low | OpenClaw | Can be reconfigured from scratch |
+
+## Related Docs
+
+- [NETWORKING.md](../NETWORKING.md)
+- [VARIABLES.md](../VARIABLES.md)
+- [OPERATIONS.md](../OPERATIONS.md)
+- [nginx-proxy-manager.md](nginx-proxy-manager.md)


### PR DESCRIPTION
## Summary

- Adds a new `duplicati` Docker Compose stack for automated encrypted backups
- Mounts `/mnt/ssd/docker-volumes` as read-only source and `/mnt/backup` (HDD) as destination
- Runs as root (PUID=0) to read files owned by various service users
- Accessible at `backup.homelab.ansh-info.com` via NPM for web UI management

## Changes

| Commit | Scope |
|--------|-------|
| `feat: add duplicati stack` | Compose file with read-only source mount, backup destination, healthcheck |
| `docs: add stack guide` | HDD setup, backup job recommendations, restore process, priorities |
| `docs: add variables` | `DUPLICATI_CONFIG_ROOT`, `DUPLICATI_HOSTNAME`, `BACKUP_ROOT` |
| `docs: update READMEs` | Links in README.md and docs/README.md |
| `docs: update CLAUDE.md and AGENTS.md` | Stack count and list |
| `ci: add to validation matrix` | CI validates compose config on push |

## Architecture

```
/mnt/ssd/docker-volumes (SSD)  -->  Duplicati  -->  /mnt/backup (HDD)
     [source, read-only]           [encrypts,        [destination]
                                    deduplicates,
                                    schedules]
```

## Prerequisites (before deploying)

1. Install internal SATA HDD (2-4 TB recommended)
2. Format, mount at `/mnt/backup`, add to `/etc/fstab` with `nofail`
3. Create config dir: `sudo mkdir -p /mnt/ssd/docker-volumes/duplicati/config`

## NPM Proxy Host Config

| Field | Value |
|-------|-------|
| Domain | `backup.homelab.ansh-info.com` |
| Scheme | `http` |
| Forward Hostname | `duplicati` |
| Forward Port | `8200` |
| SSL Certificate | `*.homelab.ansh-info.com` wildcard |

## Test plan

- [x] `docker compose config` validates cleanly
- [ ] Container starts and healthcheck passes (requires /mnt/backup mounted)
- [ ] Accessible via `backup.homelab.ansh-info.com` through NPM
- [ ] Can browse /source (docker-volumes) in backup job wizard
- [ ] Can write test backup to /backups
- [ ] CI validation passes for the new matrix entry