### PR TITLE
feat: add Librarr and Kavita for book automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Eight compose stacks under `docker-compose/`:
 
 - `pihole` - DNS authority (port 53 on host)
 - `nginx-proxy-manager` - Reverse proxy (ports 80, 443 on host)
-- `jellyfin-arr-stack` - Media: Jellyfin (NVIDIA GPU), Radarr, Sonarr, Prowlarr, Bazarr, Homarr, qBittorrent, Seerr
+- `jellyfin-arr-stack` - Media: Jellyfin (NVIDIA GPU), Radarr, Sonarr, Prowlarr, Bazarr, Librarr, Kavita, Homarr, qBittorrent, Seerr
 - `immich` - Photo management (uses `stack.env` for config)
 - `nextcloud-aio` - Cloud storage (two NPM hosts: admin + app)
 - `openclaw` - AI assistant gateway (stateful, manual updates only)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The main service definitions live under [docker-compose](docker-compose):
 
 - [docker-compose/pihole/docker-compose.yml](docker-compose/pihole/docker-compose.yml)
 - [docker-compose/nginx-proxy-manager/docker-compose.yml](docker-compose/nginx-proxy-manager/docker-compose.yml)
-- [docker-compose/jellyfin-arr-stack/docker-compose.yml](docker-compose/jellyfin-arr-stack/docker-compose.yml)
+- [docker-compose/jellyfin-arr-stack/docker-compose.yml](docker-compose/jellyfin-arr-stack/docker-compose.yml) (includes Librarr + Kavita for books)
 - [docker-compose/immich/docker-compose.yml](docker-compose/immich/docker-compose.yml)
 - [docker-compose/nextcloud-aio/docker-compose.yml](docker-compose/nextcloud-aio/docker-compose.yml)
 - [docker-compose/openclaw/docker-compose.yml](docker-compose/openclaw/docker-compose.yml)

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -90,6 +90,9 @@ services:
     dns:
       - 1.1.1.1
       - 8.8.8.8
+    extra_hosts:
+      - "annas-archive.gl:127.0.0.1"
+      - "libgen.li:127.0.0.1"
     volumes:
       - /mnt/ssd/docker-volumes/arr/librarr/data:/data
       - /mnt/ssd/docker-volumes/arr/librarr/books:/books

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -92,7 +92,7 @@ services:
       - /mnt/ssd/docker-volumes/arr/librarr/books:/books
       - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
     # ports:
-    #   - 8787:8787
+    #   - 5050:5050
     networks:
       - proxy
     restart: unless-stopped

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     volumes:
       - /mnt/ssd/docker-volumes/arr/librarr/data:/data
       - /mnt/ssd/docker-volumes/arr/librarr/books:/books

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -80,20 +80,36 @@ services:
   #     - 8686:8686
   #   restart: unless-stopped
 
-  # readarr:
-  #   image: lscr.io/linuxserver/readarr:amd64-nightly-0.4.0.2593-ls334
-  #   container_name: readarr
-  #   environment:
-  #     - PUID=1000
-  #     - PGID=1000
-  #     - TZ=Etc/UTC
-  #   volumes:
-  #     - /mnt/ssd/docker-volumes/arr/readarr/config:/config
-  #     - /mnt/ssd/docker-volumes/arr/readarr/books:/data/books
-  #     - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
-  #   ports:
-  #     - 8787:8787
-  #   restart: unless-stopped
+  librarr:
+    image: ghcr.io/jeremiahm37/librarr:latest
+    container_name: librarr
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC
+    volumes:
+      - /mnt/ssd/docker-volumes/arr/librarr/config:/config
+      - /mnt/ssd/docker-volumes/arr/librarr/books:/books
+      - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
+    # ports:
+    #   - 8787:8787
+    networks:
+      - proxy
+    restart: unless-stopped
+
+  kavita:
+    image: jvmilazz0/kavita:latest
+    container_name: kavita
+    environment:
+      - TZ=Etc/UTC
+    volumes:
+      - /mnt/ssd/docker-volumes/arr/kavita/config:/kavita/config
+      - /mnt/ssd/docker-volumes/arr/librarr/books:/books
+    # ports:
+    #   - 5000:5000
+    networks:
+      - proxy
+    restart: unless-stopped
 
   homarr:
     image: ghcr.io/ajnart/homarr:latest
@@ -145,8 +161,8 @@ services:
       - /mnt/ssd/docker-volumes/arr/jellyfin/config:/config
       - /mnt/ssd/docker-volumes/arr/sonarr/tvseries:/data/tvshows
       - /mnt/ssd/docker-volumes/arr/radarr/movies:/data/movies
-      - /mnt/ssd/docker-volumes/arr/readarr/books:/data/books
-      - /mnt/ssd/docker-volumes/arr/lidarr/music:/data/music
+      - /mnt/ssd/docker-volumes/arr/librarr/books:/data/books
+      # - /mnt/ssd/docker-volumes/arr/lidarr/music:/data/music
     ports:
       # - 8096:8096
       - 8920:8920

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - PGID=1000
       - TZ=Etc/UTC
     volumes:
-      - /mnt/ssd/docker-volumes/arr/librarr/config:/config
+      - /mnt/ssd/docker-volumes/arr/librarr/data:/data
       - /mnt/ssd/docker-volumes/arr/librarr/books:/books
       - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
     # ports:

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -77,6 +77,16 @@ The placeholders are documentation variables only. They are not automatically ex
 | `${ACTUAL_DATA_ROOT}` | Host path for Actual Budget persistent data | `/mnt/ssd/docker-volumes/actual-budget/data` |
 | `${ACTUAL_HOSTNAME}` | Private hostname for Actual Budget | `actual.homelab.ansh-info.com` |
 
+## Librarr and Kavita Variables
+
+| Variable | Meaning | Current Example |
+| --- | --- | --- |
+| `${LIBRARR_CONFIG_ROOT}` | Host path for Librarr config | `/mnt/ssd/docker-volumes/arr/librarr/config` |
+| `${LIBRARR_BOOKS_ROOT}` | Host path for Librarr book library (shared with Kavita and Jellyfin) | `/mnt/ssd/docker-volumes/arr/librarr/books` |
+| `${KAVITA_CONFIG_ROOT}` | Host path for Kavita config | `/mnt/ssd/docker-volumes/arr/kavita/config` |
+| `${LIBRARR_HOSTNAME}` | Private hostname for Librarr | `librarr.homelab.ansh-info.com` |
+| `${KAVITA_HOSTNAME}` | Private hostname for Kavita | `kavita.homelab.ansh-info.com` |
+
 ## Notes
 
 - When multiple docs mention the same variable, prefer using the definitions in this file rather than inventing a new variant.

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -81,7 +81,7 @@ The placeholders are documentation variables only. They are not automatically ex
 
 | Variable | Meaning | Current Example |
 | --- | --- | --- |
-| `${LIBRARR_CONFIG_ROOT}` | Host path for Librarr config | `/mnt/ssd/docker-volumes/arr/librarr/config` |
+| `${LIBRARR_DATA_ROOT}` | Host path for Librarr data (database and settings) | `/mnt/ssd/docker-volumes/arr/librarr/data` |
 | `${LIBRARR_BOOKS_ROOT}` | Host path for Librarr book library (shared with Kavita and Jellyfin) | `/mnt/ssd/docker-volumes/arr/librarr/books` |
 | `${KAVITA_CONFIG_ROOT}` | Host path for Kavita config | `/mnt/ssd/docker-volumes/arr/kavita/config` |
 | `${LIBRARR_HOSTNAME}` | Private hostname for Librarr | `librarr.homelab.ansh-info.com` |

--- a/docs/stacks/jellyfin-arr-stack.md
+++ b/docs/stacks/jellyfin-arr-stack.md
@@ -22,18 +22,20 @@ The current compose file includes:
 - `bazarr`
 - `qbittorrent`
 - `homarr`
+- `librarr` (book/ebook automation - Readarr replacement)
+- `kavita` (ebook reader and library server)
 
 Currently commented out in the checked-in compose file:
 
 - `lidarr`
 - `plex`
-- `readarr`
 
 These services do not all play the same role:
 
 - `jellyfin` and `plex` serve media
+- `kavita` serves ebooks/comics with a web reader
 - `seerr` is the request UI
-- `radarr`, `sonarr`, `bazarr`, and `prowlarr` coordinate discovery and metadata
+- `radarr`, `sonarr`, `bazarr`, `librarr`, and `prowlarr` coordinate discovery and metadata
 - `qbittorrent` handles downloads
 - `homarr` is a dashboard layer
 
@@ -105,6 +107,14 @@ Current important service details from the compose file:
   - internal web UI port `8080`
   - torrent port `6881` exposed on host
   - attached to `${PROXY_NETWORK}`
+- `librarr`
+  - internal port `8787`
+  - attached to `${PROXY_NETWORK}`
+  - intended to be reverse-proxied
+- `kavita`
+  - internal port `5000`
+  - attached to `${PROXY_NETWORK}`
+  - intended to be reverse-proxied
 - `homarr`
   - currently present but not attached to `${PROXY_NETWORK}` in the compose file
 - `lidarr`
@@ -128,6 +138,9 @@ Examples from the current compose file:
 - `${CONFIG_ROOT}/qbittorrent/downloads`
 - `${CONFIG_ROOT}/radarr/movies`
 - `${CONFIG_ROOT}/sonarr/tvseries`
+- `${CONFIG_ROOT}/librarr/config`
+- `${CONFIG_ROOT}/librarr/books`
+- `${CONFIG_ROOT}/kavita/config`
 - `${CONFIG_ROOT}/homarr/config`
 - `${CONFIG_ROOT}/homarr/icons`
 - `${CONFIG_ROOT}/homarr/data`
@@ -144,6 +157,9 @@ Current migrated host layout:
 - `/mnt/ssd/docker-volumes/arr/qbittorrent/downloads`
 - `/mnt/ssd/docker-volumes/arr/jellyfin/config`
 - `/mnt/ssd/docker-volumes/arr/seerr/config`
+- `/mnt/ssd/docker-volumes/arr/librarr/config`
+- `/mnt/ssd/docker-volumes/arr/librarr/books`
+- `/mnt/ssd/docker-volumes/arr/kavita/config`
 - `/mnt/ssd/docker-volumes/arr/homarr/config`
 - `/mnt/ssd/docker-volumes/arr/homarr/icons`
 - `/mnt/ssd/docker-volumes/arr/homarr/data`
@@ -206,6 +222,8 @@ Expected reverse-proxy targets include:
 - `prowlarr.${DOMAIN_ROOT}` -> `prowlarr:9696`
 - `bazarr.${DOMAIN_ROOT}` -> `bazarr:6767`
 - `jellyfin.${DOMAIN_ROOT}` -> `jellyfin:8096`
+- `librarr.${DOMAIN_ROOT}` -> `librarr:8787`
+- `kavita.${DOMAIN_ROOT}` -> `kavita:5000`
 
 Current exceptions in the compose file:
 
@@ -294,6 +312,8 @@ Look especially for:
 - `sonarr`
 - `prowlarr`
 - `bazarr`
+- `librarr`
+- `kavita`
 - `jellyfin`
 - `qbittorrent`
 - `homarr`
@@ -304,7 +324,7 @@ Look especially for:
 docker network inspect ${PROXY_NETWORK}
 ```
 
-For normal NPM access, services like `seerr`, `radarr`, `sonarr`, `prowlarr`, `bazarr`, `jellyfin`, and `qbittorrent` should appear on `${PROXY_NETWORK}`.
+For normal NPM access, services like `seerr`, `radarr`, `sonarr`, `prowlarr`, `bazarr`, `librarr`, `kavita`, `jellyfin`, and `qbittorrent` should appear on `${PROXY_NETWORK}`.
 
 Do not assume `homarr` will appear there unless the compose file is changed. `lidarr` and `plex` are currently commented out.
 
@@ -377,6 +397,8 @@ Typical targets for this stack:
 - `prowlarr.${DOMAIN_ROOT}` -> `prowlarr:9696`
 - `bazarr.${DOMAIN_ROOT}` -> `bazarr:6767`
 - `jellyfin.${DOMAIN_ROOT}` -> `jellyfin:8096`
+- `librarr.${DOMAIN_ROOT}` -> `librarr:8787`
+- `kavita.${DOMAIN_ROOT}` -> `kavita:5000`
 
 ### How To Fill NPM For These Services
 
@@ -390,6 +412,8 @@ For the active services in this stack, the practical NPM pattern is:
 | `prowlarr.${DOMAIN_ROOT}` | `http` | `prowlarr` | `9696` |
 | `bazarr.${DOMAIN_ROOT}` | `http` | `bazarr` | `6767` |
 | `jellyfin.${DOMAIN_ROOT}` | `http` | `jellyfin` | `8096` |
+| `librarr.${DOMAIN_ROOT}` | `http` | `librarr` | `8787` |
+| `kavita.${DOMAIN_ROOT}` | `http` | `kavita` | `5000` |
 
 Recommended NPM toggles for these entries:
 

--- a/docs/stacks/jellyfin-arr-stack.md
+++ b/docs/stacks/jellyfin-arr-stack.md
@@ -108,7 +108,7 @@ Current important service details from the compose file:
   - torrent port `6881` exposed on host
   - attached to `${PROXY_NETWORK}`
 - `librarr`
-  - internal port `8787`
+  - internal port `5050`
   - attached to `${PROXY_NETWORK}`
   - intended to be reverse-proxied
 - `kavita`
@@ -138,7 +138,7 @@ Examples from the current compose file:
 - `${CONFIG_ROOT}/qbittorrent/downloads`
 - `${CONFIG_ROOT}/radarr/movies`
 - `${CONFIG_ROOT}/sonarr/tvseries`
-- `${CONFIG_ROOT}/librarr/config`
+- `${CONFIG_ROOT}/librarr/data`
 - `${CONFIG_ROOT}/librarr/books`
 - `${CONFIG_ROOT}/kavita/config`
 - `${CONFIG_ROOT}/homarr/config`
@@ -157,7 +157,7 @@ Current migrated host layout:
 - `/mnt/ssd/docker-volumes/arr/qbittorrent/downloads`
 - `/mnt/ssd/docker-volumes/arr/jellyfin/config`
 - `/mnt/ssd/docker-volumes/arr/seerr/config`
-- `/mnt/ssd/docker-volumes/arr/librarr/config`
+- `/mnt/ssd/docker-volumes/arr/librarr/data`
 - `/mnt/ssd/docker-volumes/arr/librarr/books`
 - `/mnt/ssd/docker-volumes/arr/kavita/config`
 - `/mnt/ssd/docker-volumes/arr/homarr/config`
@@ -222,7 +222,7 @@ Expected reverse-proxy targets include:
 - `prowlarr.${DOMAIN_ROOT}` -> `prowlarr:9696`
 - `bazarr.${DOMAIN_ROOT}` -> `bazarr:6767`
 - `jellyfin.${DOMAIN_ROOT}` -> `jellyfin:8096`
-- `librarr.${DOMAIN_ROOT}` -> `librarr:8787`
+- `librarr.${DOMAIN_ROOT}` -> `librarr:5050`
 - `kavita.${DOMAIN_ROOT}` -> `kavita:5000`
 
 Current exceptions in the compose file:
@@ -397,7 +397,7 @@ Typical targets for this stack:
 - `prowlarr.${DOMAIN_ROOT}` -> `prowlarr:9696`
 - `bazarr.${DOMAIN_ROOT}` -> `bazarr:6767`
 - `jellyfin.${DOMAIN_ROOT}` -> `jellyfin:8096`
-- `librarr.${DOMAIN_ROOT}` -> `librarr:8787`
+- `librarr.${DOMAIN_ROOT}` -> `librarr:5050`
 - `kavita.${DOMAIN_ROOT}` -> `kavita:5000`
 
 ### How To Fill NPM For These Services
@@ -412,7 +412,7 @@ For the active services in this stack, the practical NPM pattern is:
 | `prowlarr.${DOMAIN_ROOT}` | `http` | `prowlarr` | `9696` |
 | `bazarr.${DOMAIN_ROOT}` | `http` | `bazarr` | `6767` |
 | `jellyfin.${DOMAIN_ROOT}` | `http` | `jellyfin` | `8096` |
-| `librarr.${DOMAIN_ROOT}` | `http` | `librarr` | `8787` |
+| `librarr.${DOMAIN_ROOT}` | `http` | `librarr` | `5050` |
 | `kavita.${DOMAIN_ROOT}` | `http` | `kavita` | `5000` |
 
 Recommended NPM toggles for these entries:


### PR DESCRIPTION
## Summary
- Adds Librarr (Readarr replacement) and Kavita (ebook reader) to the jellyfin-arr-stack
- Librarr handles book search/download via Prowlarr + qBittorrent integration
- Kavita provides a web-based reading UI with OPDS support
- Shared books directory between Librarr, Kavita, and Jellyfin
- Updated Jellyfin books mount from deprecated readarr path to librarr path

## NPM configuration needed after deploy
| Hostname | Forward to |
|----------|-----------|
| `librarr.homelab.ansh-info.com` | `librarr:8787` |
| `kavita.homelab.ansh-info.com` | `kavita:5000` |

## Host directories to create before deploy
```bash
mkdir -p /mnt/ssd/docker-volumes/arr/librarr/{config,books}
mkdir -p /mnt/ssd/docker-volumes/arr/kavita/config
```

## Test plan
- [ ] `docker compose config` passes (CI validates)
- [ ] Deploy via Portainer, confirm both containers start
- [ ] Access `librarr.homelab.ansh-info.com` through NPM
- [ ] Access `kavita.homelab.ansh-info.com` through NPM
- [ ] Configure Librarr to use existing Prowlarr + qBittorrent
- [ ] Test book search and download flow
- [ ] Verify downloaded books appear in Kavita library
- [ ] Verify Jellyfin sees books at `/data/books`