### PR TITLE
docs: add inline documentation to all docker-compose stacks

### DIFF
--- a/docker-compose/actual-budget/docker-compose.yml
+++ b/docker-compose/actual-budget/docker-compose.yml
@@ -1,3 +1,17 @@
+# =============================================================================
+# Actual Budget - Personal Finance and Envelope Budgeting
+# =============================================================================
+# Self-hosted budgeting application using the envelope method. Provides
+# transaction tracking, budget categories, and financial reporting.
+#
+# Access: budget.homelab.ansh-info.com (reverse-proxied through NPM)
+# Internal port: 5006
+# No host ports exposed - NPM handles all ingress via the proxy network.
+#
+# Data: All budget data, accounts, and transactions stored in /data volume.
+# Backup priority: HIGH - contains financial records with no external sync.
+# =============================================================================
+
 services:
   actual-budget:
     image: actualbudget/actual-server:latest-alpine
@@ -6,6 +20,7 @@ services:
     environment:
       TZ: "Asia/Kolkata"
     volumes:
+      # Budget database, account files, and user data
       - /mnt/ssd/docker-volumes/actual-budget/data:/data
     networks:
       - proxy

--- a/docker-compose/immich/docker-compose.yml
+++ b/docker-compose/immich/docker-compose.yml
@@ -1,3 +1,33 @@
+# =============================================================================
+# Immich - Self-Hosted Photo and Video Management
+# =============================================================================
+# Google Photos alternative with facial recognition, smart search, timeline
+# browsing, sharing albums, and mobile auto-upload. Uses machine learning
+# for automatic tagging, CLIP embeddings for natural language search, and
+# vector similarity for face clustering.
+#
+# Architecture (4 services):
+#   immich-server:           API + web UI (port 2283 internally)
+#   immich-machine-learning: Facial recognition, CLIP embeddings, smart tags
+#   redis (Valkey):          Session cache, job queues (BullMQ), pub/sub
+#   database (PostgreSQL):   Metadata + vector search (pgvectors + vectorchord)
+#
+# Access: immich.homelab.ansh-info.com (reverse-proxied through NPM)
+# Internal port: 2283 (immich-server)
+# No host ports exposed - NPM handles all ingress via the proxy network.
+#
+# Configuration: Uses stack.env (not .env) - see env_file directive.
+#   Required vars: UPLOAD_LOCATION, DB_DATA_LOCATION, DB_PASSWORD,
+#                  DB_USERNAME, DB_DATABASE_NAME
+#
+# Storage layout:
+#   /mnt/ssd/docker-volumes/immich/library    - Photo/video uploads
+#   /mnt/ssd/docker-volumes/immich/postgres   - PostgreSQL data
+#   /mnt/ssd/docker-volumes/immich/model-cache - ML models (persisted on SSD)
+#
+# Backup priority: CRITICAL - photos are irreplaceable.
+# =============================================================================
+
 #
 # WARNING: To install Immich, follow our guide: https://immich.app/docs/install/docker-compose
 #
@@ -10,6 +40,11 @@
 name: immich
 
 services:
+  # ---------------------------------------------------------------------------
+  # Immich Server - Core API and Web Interface
+  # Handles uploads, thumbnail generation, metadata extraction, and serves
+  # the web UI. This is the only service NPM routes external traffic to.
+  # ---------------------------------------------------------------------------
   immich-server:
     container_name: immich_server
     image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
@@ -20,6 +55,7 @@ services:
       # Do not edit the next line. If you want to change the media storage location on your system, edit the value of UPLOAD_LOCATION in the .env file
       - ${UPLOAD_LOCATION}:/data
       - /etc/localtime:/etc/localtime:ro
+    # stack.env (not .env) - Immich convention for Portainer compatibility
     env_file:
       - stack.env
     # ports:
@@ -33,6 +69,11 @@ services:
     healthcheck:
       disable: false
 
+  # ---------------------------------------------------------------------------
+  # Immich Machine Learning - AI/ML Processing
+  # Runs facial recognition, CLIP embeddings (for natural language photo search),
+  # and automatic tagging. Downloads models on first run and caches them.
+  # ---------------------------------------------------------------------------
   immich-machine-learning:
     container_name: immich_machine_learning
     # For hardware acceleration, add one of -[armnn, cuda, rocm, openvino, rknn] to the image tag.
@@ -43,6 +84,7 @@ services:
     #   service: cpu # set to one of [armnn, cuda, rocm, openvino, openvino-wsl, rknn] for accelerated inference - use the `-wsl` version for WSL2 where applicable
     volumes:
       # - model-cache:/cache
+      # ML models persisted on SSD to avoid re-downloading (~2GB) on container recreate
       - /mnt/ssd/docker-volumes/immich/model-cache:/cache # <— persist models on SSD
     env_file:
       - stack.env
@@ -52,6 +94,12 @@ services:
     healthcheck:
       disable: false
 
+  # ---------------------------------------------------------------------------
+  # Redis (Valkey) - Caching and Job Queue
+  # Provides session caching, BullMQ job queues for background tasks (thumbnail
+  # generation, ML processing), and pub/sub for real-time notifications.
+  # Image pinned with SHA256 for reproducible deployments.
+  # ---------------------------------------------------------------------------
   redis:
     container_name: immich_redis
     image: docker.io/valkey/valkey:8-bookworm@sha256:fea8b3e67b15729d4bb70589eb03367bab9ad1ee89c876f54327fc7c6e618571
@@ -61,6 +109,13 @@ services:
       - proxy
     restart: always
 
+  # ---------------------------------------------------------------------------
+  # PostgreSQL - Metadata and Vector Search Database
+  # Specialized image with vectorchord (approximate nearest neighbor indexes)
+  # and pgvectors (embedding storage) extensions. These enable similarity
+  # search for faces and CLIP embeddings without a separate vector database.
+  # Image pinned with SHA256 for data safety - never auto-upgrade databases.
+  # ---------------------------------------------------------------------------
   database:
     container_name: immich_postgres
     image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:c44be5f2871c59362966d71eab4268170eb6f5653c0e6170184e72b38ffdf107
@@ -68,18 +123,23 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
+      # Data checksums detect silent corruption in PostgreSQL data files
       POSTGRES_INITDB_ARGS: "--data-checksums"
       # Uncomment the DB_STORAGE_TYPE: 'HDD' var if your database isn't stored on SSDs
       # DB_STORAGE_TYPE: 'HDD'
     volumes:
       # Do not edit the next line. If you want to change the database storage location on your system, edit the value of DB_DATA_LOCATION in the .env file
       - ${DB_DATA_LOCATION}:/var/lib/postgresql/data
+    # Increased shared memory for PostgreSQL operations (default 64mb is too low)
     shm_size: 128mb
     networks:
       - proxy
     restart: always
 # volumes:
 #   model-cache:
+
+# External network shared with NPM and all other reverse-proxied services.
+# Must be pre-created: docker network create proxy
 networks:
   proxy:
     external: true

--- a/docker-compose/jellyfin-arr-stack/docker-compose.yml
+++ b/docker-compose/jellyfin-arr-stack/docker-compose.yml
@@ -1,21 +1,67 @@
+# =============================================================================
+# Jellyfin + Arr Stack - Media Automation and Streaming
+# =============================================================================
+# Complete media automation pipeline from request to streaming. Users request
+# content through Seerr, which triggers the download-import-stream workflow.
+#
+# Data flow:
+#   Seerr (request) --> Radarr/Sonarr (manage) --> Prowlarr (search indexers)
+#   --> qBittorrent (download) --> Radarr/Sonarr (import to library)
+#   --> Jellyfin (stream) + Bazarr (fetch subtitles)
+#
+# Architecture:
+#   Seerr:        User-facing request portal ("what do you want to watch?")
+#   Radarr:       Movie library manager (monitors, grabs, imports)
+#   Sonarr:       TV series library manager (same role as Radarr for shows)
+#   Prowlarr:     Indexer aggregator (single config point for all indexers)
+#   qBittorrent:  BitTorrent download client
+#   Bazarr:       Subtitle companion (fetches .srt files for media)
+#   Jellyfin:     Media streaming server with NVIDIA GPU hardware transcoding
+#   Homarr:       Dashboard showing stack status at a glance
+#
+# Networking: All services join the "proxy" network for NPM reverse proxying.
+#   No web UI ports are exposed to the host - NPM handles ingress for each
+#   service via its own hostname (e.g., radarr.homelab.ansh-info.com).
+#   Exception: qBittorrent exposes port 6881 for BitTorrent peer connections.
+#
+# Storage strategy: All services share paths under /mnt/ssd/docker-volumes/arr/
+#   so that hardlinks work for imports (no file copying, instant moves).
+#   The /downloads path is shared between qBittorrent and Radarr/Sonarr.
+# =============================================================================
+
 services:
+  # ---------------------------------------------------------------------------
+  # Radarr - Movie Library Manager
+  # Monitors wanted movies, searches via Prowlarr, sends to qBittorrent,
+  # and imports completed downloads into the movie library.
+  # Access: radarr.homelab.ansh-info.com | Internal port: 7878
+  # ---------------------------------------------------------------------------
   radarr:
     image: lscr.io/linuxserver/radarr:latest
     container_name: radarr
     environment:
+      # PUID/PGID match host user for consistent file ownership across shared volumes
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
     volumes:
       - /mnt/ssd/docker-volumes/arr/radarr/config:/config
       - /mnt/ssd/docker-volumes/arr/radarr/movies:/data/movies
+      # Shared with qBittorrent - enables hardlink imports (no copy, instant move)
       - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
+    # Port not exposed to host - accessed via NPM reverse proxy
     # ports:
     #   - 7878:7878
     networks:
       - proxy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Sonarr - TV Series Library Manager
+  # Same role as Radarr but for TV shows. Monitors series, grabs episodes,
+  # and manages the TV library with season/episode organization.
+  # Access: sonarr.homelab.ansh-info.com | Internal port: 8989
+  # ---------------------------------------------------------------------------
   sonarr:
     image: lscr.io/linuxserver/sonarr:latest
     container_name: sonarr
@@ -26,6 +72,7 @@ services:
     volumes:
       - /mnt/ssd/docker-volumes/arr/sonarr/config:/config
       - /mnt/ssd/docker-volumes/arr/sonarr/tvseries:/data/tvshows
+      # Shared with qBittorrent - enables hardlink imports
       - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
     # ports:
     #   - 8989:8989
@@ -33,6 +80,12 @@ services:
       - proxy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Prowlarr - Indexer Aggregator
+  # Single configuration point for torrent/usenet indexers. Radarr and Sonarr
+  # connect to Prowlarr instead of managing indexers individually.
+  # Access: prowlarr.homelab.ansh-info.com | Internal port: 9696
+  # ---------------------------------------------------------------------------
   prowlarr:
     image: lscr.io/linuxserver/prowlarr:latest
     container_name: prowlarr
@@ -48,6 +101,12 @@ services:
       - proxy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Bazarr - Subtitle Manager
+  # Companion to Radarr/Sonarr that automatically fetches subtitles for media.
+  # Mounts the same movie/TV paths so it can write .srt files alongside media.
+  # Access: bazarr.homelab.ansh-info.com | Internal port: 6767
+  # ---------------------------------------------------------------------------
   bazarr:
     image: lscr.io/linuxserver/bazarr:latest
     container_name: bazarr
@@ -57,7 +116,9 @@ services:
       - TZ=Etc/UTC
     volumes:
       - /mnt/ssd/docker-volumes/arr/bazarr/config:/config
+      # Mounts Radarr's movie library to write subtitle files alongside media
       - /mnt/ssd/docker-volumes/arr/radarr/movies:/data/movies
+      # Mounts Sonarr's TV library for the same reason
       - /mnt/ssd/docker-volumes/arr/sonarr/tvseries:/data/tvshows
     # ports:
     #   - 6767:6767
@@ -95,6 +156,12 @@ services:
   #     - 8787:8787
   #   restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Homarr - Dashboard
+  # At-a-glance overview of all arr stack services. Shows status, quick links,
+  # and integration widgets for each service.
+  # Access: homarr.homelab.ansh-info.com | Internal port: 7575
+  # ---------------------------------------------------------------------------
   homarr:
     image: ghcr.io/ajnart/homarr:latest
     container_name: homarr
@@ -110,6 +177,13 @@ services:
     networks:
       - proxy
 
+  # ---------------------------------------------------------------------------
+  # qBittorrent - BitTorrent Download Client
+  # Downloads media files requested by Radarr/Sonarr. The /downloads volume
+  # is shared with Radarr and Sonarr so they can hardlink files into the
+  # library without copying (instant, zero extra disk space).
+  # Access: qbit.homelab.ansh-info.com | Internal WebUI port: 8080
+  # ---------------------------------------------------------------------------
   qbittorrent:
     image: lscr.io/linuxserver/qbittorrent:latest
     container_name: qbittorrent
@@ -124,12 +198,25 @@ services:
       - /mnt/ssd/docker-volumes/arr/qbittorrent/downloads:/downloads
     ports:
       # - 8080:8080
+      # BitTorrent peer connection port - must be exposed for incoming connections
       - 6881:6881
       - 6881:6881/udp
     networks:
       - proxy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Jellyfin - Media Streaming Server
+  # Streams movies, TV shows, music, and books to all devices. Uses NVIDIA GPU
+  # for hardware transcoding (converting video formats/bitrates on the fly).
+  # Access: jellyfin.homelab.ansh-info.com | Internal port: 8096
+  #
+  # NVIDIA GPU: runtime: nvidia enables GPU passthrough for hardware transcoding.
+  #   NVIDIA_VISIBLE_DEVICES=all makes all GPUs available to the container.
+  #   NVIDIA_DRIVER_CAPABILITIES=compute,video,utility enables NVENC/NVDEC.
+  #   DO NOT remove these - streaming without GPU transcoding will fail for
+  #   clients that don't support the source format directly.
+  # ---------------------------------------------------------------------------
   jellyfin:
     image: lscr.io/linuxserver/jellyfin:latest
     container_name: jellyfin
@@ -143,6 +230,7 @@ services:
       - NVIDIA_DRIVER_CAPABILITIES=compute,video,utility
     volumes:
       - /mnt/ssd/docker-volumes/arr/jellyfin/config:/config
+      # Read-only access to all media libraries managed by the arr services
       - /mnt/ssd/docker-volumes/arr/sonarr/tvseries:/data/tvshows
       - /mnt/ssd/docker-volumes/arr/radarr/movies:/data/movies
       - /mnt/ssd/docker-volumes/arr/readarr/books:/data/books
@@ -156,9 +244,17 @@ services:
       - proxy
     restart: unless-stopped
 
+  # ---------------------------------------------------------------------------
+  # Seerr - Media Request Management
+  # User-facing portal where users request movies/shows. Integrates with
+  # Radarr and Sonarr to automatically add requested content to their queues.
+  # This is the "front door" to the entire media automation pipeline.
+  # Access: seerr.homelab.ansh-info.com | Internal port: 5055
+  # ---------------------------------------------------------------------------
   seerr:
     image: ghcr.io/seerr-team/seerr:latest
     container_name: seerr
+    # init: true ensures proper signal handling for the Node.js process
     init: true
     environment:
       - LOG_LEVEL=info
@@ -217,6 +313,9 @@ services:
   #             device_ids: ["0"]
   #   restart: unless-stopped
 
+# External network shared with NPM and all other reverse-proxied services.
+# All services join this so NPM can route by hostname without host port exposure.
+# Must be pre-created: docker network create proxy
 networks:
   proxy:
     external: true

--- a/docker-compose/nextcloud-aio/docker-compose.yml
+++ b/docker-compose/nextcloud-aio/docker-compose.yml
@@ -1,3 +1,31 @@
+# =============================================================================
+# Nextcloud AIO - Self-Hosted Cloud Storage
+# =============================================================================
+# Nextcloud All-in-One is an orchestrator container that manages the full
+# Nextcloud stack (web server, database, redis, cron, etc.) as sibling
+# containers via the Docker socket.
+#
+# Architecture:
+#   - This compose file only defines the "mastercontainer"
+#   - The mastercontainer spawns and manages other containers automatically
+#   - Spawned containers join the "proxy" network via APACHE_ADDITIONAL_NETWORK
+#
+# Access (two hostnames via NPM):
+#   - nextcloud.homelab.ansh-info.com --> localhost:11000 (the Nextcloud app)
+#   - nextcloud-admin.homelab.ansh-info.com --> mastercontainer:8080 (AIO admin)
+#
+# Reverse proxy setup:
+#   - APACHE_PORT=11000: internal port the spawned Apache container listens on
+#   - APACHE_IP_BINDING=127.0.0.1: only accept connections from localhost/NPM
+#   - APACHE_ADDITIONAL_NETWORK=proxy: spawned containers join the proxy network
+#
+# IMPORTANT: The container_name "nextcloud-aio-mastercontainer" is immutable.
+#   Changing it will break AIO's internal container management and backup system.
+#
+# Storage: Data stored at /mnt/ssd/docker-volumes/nextcloud/data
+# GPU: NVIDIA GPU enabled for Memories app video transcoding
+# =============================================================================
+
 services:
   nextcloud-aio-mastercontainer:
     image: ghcr.io/nextcloud-releases/all-in-one:latest # This is the container image used. You can switch to ghcr.io/nextcloud-releases/all-in-one:beta if you want to help testing new releases. See https://github.com/nextcloud/all-in-one#how-to-switch-the-channel
@@ -18,8 +46,11 @@ services:
     # security_opt: ["label:disable"] # Is needed when using SELinux. See https://github.com/nextcloud/all-in-one#are-there-known-problems-when-selinux-is-enabled
     environment: # Is needed when using any of the options below
       # AIO_DISABLE_BACKUP_SECTION: false # Setting this to true allows to hide the backup section in the AIO interface. See https://github.com/nextcloud/all-in-one#how-to-disable-the-backup-section
+      # Internal port for the spawned Apache container (NPM proxies to this)
       APACHE_PORT: 11000 # Is needed when running behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else). See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
+      # Bind Apache to localhost only - NPM on the same host handles external traffic
       APACHE_IP_BINDING: 127.0.0.1 # Should be set when running behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else) that is running on the same host. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
+      # Connect spawned containers to the proxy network so NPM can reach them
       APACHE_ADDITIONAL_NETWORK: proxy # (Optional) Connect the apache container to an additional docker network. Needed when behind a web server or reverse proxy (like Apache, Nginx, Caddy, Cloudflare Tunnel and else) running in a different docker network on same server. See https://github.com/nextcloud/all-in-one/blob/main/reverse-proxy.md
       # BORG_RETENTION_POLICY: --keep-within=7d --keep-weekly=4 --keep-monthly=6 # Allows to adjust borgs retention policy. See https://github.com/nextcloud/all-in-one#how-to-adjust-borgs-retention-policy
       # COLLABORA_SECCOMP_DISABLED: false # Setting this to true allows to disable Collabora's Seccomp feature. See https://github.com/nextcloud/all-in-one#how-to-disable-collaboras-seccomp-feature
@@ -36,9 +67,11 @@ services:
       # NEXTCLOUD_ENABLE_DRI_DEVICE: true # This allows to enable the /dev/dri device for containers that profit from it. ⚠️⚠️⚠️ Warning: this only works if the '/dev/dri' device is present on the host! If it should not exist on your host, don't set this to true as otherwise the Nextcloud container will fail to start! See https://github.com/nextcloud/all-in-one#how-to-enable-hardware-acceleration-for-nextcloud
       NEXTCLOUD_ENABLE_NVIDIA_GPU: true # This allows to enable the NVIDIA runtime and GPU access for containers that profit from it. ⚠️⚠️⚠️ Warning: this only works if an NVIDIA gpu is installed on the server. See https://github.com/nextcloud/all-in-one#how-to-enable-hardware-acceleration-for-nextcloud.
       # NEXTCLOUD_KEEP_DISABLED_APPS: false # Setting this to true will keep Nextcloud apps that are disabled in the AIO interface and not uninstall them if they should be installed. See https://github.com/nextcloud/all-in-one#how-to-keep-disabled-apps
+      # Skip domain validation since we handle routing through NPM and Tailscale
       SKIP_DOMAIN_VALIDATION: true # This should only be set to true if things are correctly configured. See https://github.com/nextcloud/all-in-one?tab=readme-ov-file#how-to-skip-the-domain-validation
       # TALK_PORT: 3478 # This allows to adjust the port that the talk container is using which is exposed on the host. See https://github.com/nextcloud/all-in-one#how-to-adjust-the-talk-port
       # WATCHTOWER_DOCKER_SOCKET_PATH: /var/run/docker.sock # Needs to be specified if the docker socket on the host is not located in the default '/var/run/docker.sock'. Otherwise mastercontainer updates will fail. For macos it needs to be '/var/run/docker.sock'
+      # Persistent data directory on SSD for all Nextcloud user files
       NEXTCLOUD_DATADIR: /mnt/ssd/docker-volumes/nextcloud/data
 
   #   # Optional: Caddy reverse proxy. See https://github.com/nextcloud/all-in-one/discussions/575

--- a/docker-compose/nginx-proxy-manager/docker-compose.yml
+++ b/docker-compose/nginx-proxy-manager/docker-compose.yml
@@ -1,3 +1,31 @@
+# =============================================================================
+# Nginx Proxy Manager - Reverse Proxy and TLS Termination
+# =============================================================================
+# NPM is the single ingress point for all homelab web services. It listens on
+# ports 80 and 443 on the host and routes traffic to backend containers based
+# on the requested hostname (SNI + Host header).
+#
+# How it works:
+#   1. Client connects to https://service.homelab.ansh-info.com
+#   2. NPM reads the SNI hostname from the TLS ClientHello
+#   3. Selects the wildcard certificate (*.homelab.ansh-info.com)
+#   4. Matches the hostname to a proxy host definition in its database
+#   5. Forwards to the target container:port on the Docker "proxy" network
+#
+# TLS certificates:
+#   - Wildcard cert: *.homelab.ansh-info.com (Let's Encrypt)
+#   - Issued via Cloudflare DNS challenge (no public HTTP endpoint needed)
+#   - Stored in /etc/letsencrypt volume
+#
+# Access: The admin UI (port 81) is NOT exposed to host. Access it via
+#   a proxy host entry pointing to nginx-proxy-manager:81, or temporarily
+#   expose port 81 for initial setup.
+#
+# IMPORTANT: Ports bind to 0.0.0.0 (not the Tailscale IP directly) to avoid
+#   a boot-time race condition where Docker starts before tailscale0 exists.
+#   UFW restricts actual access to the tailscale0 interface.
+# =============================================================================
+
 services:
   app:
     image: "jc21/nginx-proxy-manager:latest"
@@ -28,7 +56,9 @@ services:
       # DISABLE_IPV6: 'true'
 
     volumes:
+      # NPM configuration, proxy host definitions, and SQLite database
       - /mnt/ssd/docker-volumes/nginx-proxy-manager/data:/data
+      # SSL certificates from Let's Encrypt (wildcard cert for *.homelab.ansh-info.com)
       - /mnt/ssd/docker-volumes/nginx-proxy-manager/letsencrypt:/etc/letsencrypt
 
 networks:

--- a/docker-compose/openclaw/docker-compose.yml
+++ b/docker-compose/openclaw/docker-compose.yml
@@ -1,16 +1,49 @@
+# =============================================================================
+# OpenClaw - AI Assistant Gateway
+# =============================================================================
+# Centralized AI assistant gateway providing access to LLM-powered tools.
+# Stateful service that maintains sessions, context, and workspace artifacts.
+#
+# Access: openclaw.homelab.ansh-info.com (reverse-proxied through NPM)
+# Internal port: 18789
+# No host ports exposed - NPM handles all ingress via the proxy network.
+#
+# IMPORTANT - Manual updates only:
+#   This service is stateful with persistent sessions and context. Do NOT add
+#   to Watchtower auto-update. Unplanned restarts or image pulls can break
+#   active sessions and lose in-progress work. Update manually when idle.
+#
+# Environment variables:
+#   Required: OPENCLAW_GATEWAY_TOKEN (set in stack.env or Portainer env)
+#   Optional: OPENAI_API_KEY, DISCORD_BOT_TOKEN
+#
+# First deployment requires bootstrap setup - see docs/stacks/openclaw.md
+# =============================================================================
+
 services:
   openclaw-gateway:
     image: ghcr.io/openclaw/openclaw:latest
     container_name: openclaw-gateway
     restart: unless-stopped
+    # init: true wraps the Node.js process with tini for proper signal handling.
+    # Without it, SIGTERM is not forwarded correctly and graceful shutdown fails.
     init: true
     environment:
+      # HOME must match volume mount so OpenClaw finds config at $HOME/.openclaw
       HOME: /home/node
+      # Enable color output in container logs
       TERM: xterm-256color
       TZ: "${OPENCLAW_TZ:-Asia/Kolkata}"
+      # Gateway auth token - the :? syntax fails startup immediately if unset,
+      # preventing an unauthenticated gateway from running on the network
       OPENCLAW_GATEWAY_TOKEN: "${OPENCLAW_GATEWAY_TOKEN:?OPENCLAW_GATEWAY_TOKEN is required}"
+      # Optional LLM provider credentials
       OPENAI_API_KEY: "${OPENAI_API_KEY:-}"
+      # Optional Discord bot integration for chat-based access
       DISCORD_BOT_TOKEN: "${DISCORD_BOT_TOKEN:-}"
+    # Gateway command:
+    #   --bind lan: listen on all interfaces (0.0.0.0) so Docker network can reach it
+    #   --port 18789: HTTP port that NPM forwards HTTPS traffic to
     command:
       [
         "node",
@@ -22,10 +55,13 @@ services:
         "18789",
       ]
     volumes:
+      # Config: settings, credentials, session state, internal databases
       - /mnt/ssd/docker-volumes/openclaw/config:/home/node/.openclaw
+      # Workspace: persistent working directory for file operations and artifacts
       - /mnt/ssd/docker-volumes/openclaw/workspace:/home/node/.openclaw/workspace
     networks:
       - proxy
+    # Healthcheck hits the gateway's /healthz endpoint (HTTP 200 when ready)
     healthcheck:
       test:
         [
@@ -37,6 +73,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
+      # Grace period for Node.js gateway initialization
       start_period: 20s
 
 networks:

--- a/docker-compose/pihole/docker-compose.yml
+++ b/docker-compose/pihole/docker-compose.yml
@@ -1,3 +1,24 @@
+# =============================================================================
+# Pi-hole - Internal DNS Authority
+# =============================================================================
+# Pi-hole serves as the DNS resolver for all homelab services. It answers
+# queries for *.homelab.ansh-info.com with the Tailscale IP of this host,
+# enabling hostname-based routing through Nginx Proxy Manager.
+#
+# Key behavior:
+#   - Wildcard DNS via dnsmasq: address=/.homelab.ansh-info.com/100.123.147.108
+#   - New services resolve immediately without adding individual records
+#   - Also provides ad-blocking for all tailnet clients
+#
+# Access: pihole.homelab.ansh-info.com (reverse-proxied through NPM)
+# Internal port: 80 (web UI), 53 (DNS)
+# Host port: 53 (TCP/UDP) - required for DNS to function
+#
+# CRITICAL: Pi-hole v6 requires FTLCONF_misc_etc_dnsmasq_d: "true" to load
+# custom dnsmasq configs from /etc/dnsmasq.d. Without it, the wildcard rule
+# file can exist on disk but will be silently ignored.
+# =============================================================================
+
 # More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
 services:
   pihole:
@@ -15,6 +36,9 @@ services:
       #- "67:67/udp"
       # Uncomment the line below if you are using Pi-hole as your NTP server
       #- "123:123/udp"
+
+      # Bound to 0.0.0.0 (not the Tailscale IP) to avoid boot race condition.
+      # UFW restricts access to tailscale0 interface only.
       - "53:53/tcp"
       - "53:53/udp"
 
@@ -32,12 +56,14 @@ services:
       # If using Docker's default `bridge` network setting the dns listening mode should be set to 'all'
       FTLCONF_dns_listeningMode: "all"
       PIHOLE_HOSTNAME: pihole
+      # CRITICAL: Without this, /etc/dnsmasq.d files (including the wildcard rule) are ignored
       FTLCONF_misc_etc_dnsmasq_d: "true"
     # Volumes store your data between container upgrades
     volumes:
       # For persisting Pi-hole's databases and common configuration file
       # - "./etc-pihole:/etc/pihole"
       - "/mnt/ssd/docker-volumes/pihole/etc-pihole:/etc/pihole"
+      # Custom dnsmasq configs (contains 99-homelab.conf with the wildcard DNS rule)
       - "/mnt/ssd/docker-volumes/pihole/etc-dnsmasq.d:/etc/dnsmasq.d"
       # Uncomment the below if you have custom dnsmasq config files that you want to persist. Not needed for most starting fresh with Pi-hole v6. If you're upgrading from v5 you and have used this directory before, you should keep it enabled for the first v6 container start to allow for a complete migration. It can be removed afterwards. Needs environment variable FTLCONF_misc_etc_dnsmasq_d: 'true'
       #- './etc-dnsmasq.d:/etc/dnsmasq.d'

--- a/docker-compose/uptime-kuma/docker-compose.yml
+++ b/docker-compose/uptime-kuma/docker-compose.yml
@@ -1,3 +1,20 @@
+# =============================================================================
+# Uptime Kuma - Service Uptime Monitoring and Alerting
+# =============================================================================
+# Monitors all homelab services for availability. Sends notifications when
+# services go down and provides a status page showing uptime history.
+#
+# Access: status.homelab.ansh-info.com (reverse-proxied through NPM)
+# Internal port: 3001
+# No host ports exposed - NPM handles all ingress via the proxy network.
+#
+# NPM IMPORTANT: Enable "WebSocket Support" in the proxy host settings.
+#   Uptime Kuma uses WebSockets for real-time dashboard updates.
+#   Without this toggle, the UI will fail to load or show stale data.
+#
+# Data: Monitor configs, notification settings, and uptime history in /app/data.
+# =============================================================================
+
 services:
   uptime-kuma:
     image: louislam/uptime-kuma:2
@@ -6,6 +23,7 @@ services:
     environment:
       TZ: "Asia/Kolkata"
     volumes:
+      # Monitor definitions, notification configs, and historical uptime data
       - /mnt/ssd/docker-volumes/uptime-kuma/data:/app/data
     networks:
       - proxy

--- a/docker-compose/vaultwarden/docker-compose.yml
+++ b/docker-compose/vaultwarden/docker-compose.yml
@@ -1,3 +1,26 @@
+# =============================================================================
+# Vaultwarden - Self-Hosted Password Manager (Bitwarden-compatible)
+# =============================================================================
+# Lightweight Bitwarden-compatible server for password management. Works with
+# all official Bitwarden clients (browser extensions, mobile apps, desktop).
+#
+# Access: vault.homelab.ansh-info.com (reverse-proxied through NPM)
+# Internal port: 80
+# No host ports exposed - NPM handles all ingress via the proxy network.
+#
+# Security notes:
+#   - SIGNUPS_ALLOWED is set to "false" after initial user creation
+#   - DOMAIN must match the actual access URL for WebSocket notifications
+#   - All vault data is encrypted client-side before reaching the server
+#
+# Initial setup:
+#   1. Deploy with SIGNUPS_ALLOWED: "true"
+#   2. Create your account via the web UI
+#   3. Redeploy with SIGNUPS_ALLOWED: "false" to lock registration
+#
+# Backup priority: CRITICAL - contains encrypted password vault.
+# =============================================================================
+
 services:
   vaultwarden:
     image: vaultwarden/server:latest
@@ -5,9 +28,12 @@ services:
     restart: unless-stopped
     environment:
       TZ: "Asia/Kolkata"
+      # Must match the public URL used to access the vault (enables WebSocket notifications)
       DOMAIN: "https://vault.homelab.ansh-info.com"
+      # Disable public registration after first user is created
       SIGNUPS_ALLOWED: "false"
     volumes:
+      # Encrypted vault data, attachments, RSA keys, and SQLite database
       - /mnt/ssd/docker-volumes/vaultwarden/data:/data
     networks:
       - proxy

--- a/docker-compose/watchtower/docker-compose.yml
+++ b/docker-compose/watchtower/docker-compose.yml
@@ -1,3 +1,26 @@
+# =============================================================================
+# Watchtower - Automatic Container Image Updates
+# =============================================================================
+# Monitors running containers and automatically pulls new images when available.
+# Runs a check every 24 hours and cleans up old images after updating.
+#
+# Access: No web UI - runs as a background daemon.
+# No network needed - communicates only via the Docker socket.
+#
+# Behavior:
+#   - Checks all running containers every 86400 seconds (24 hours)
+#   - Pulls new images and recreates containers with same config
+#   - --cleanup removes old images after successful update
+#   - Docker socket mounted read-only (:ro) for safety
+#
+# WARNING: Watchtower updates ALL containers indiscriminately. For stateful
+#   services that require careful migration (like OpenClaw), consider using
+#   label-based exclusion: com.centurylinklabs.watchtower.enable=false
+#
+# IMPORTANT: Do NOT change the docker.sock mount to read-write. Read-only
+#   is sufficient for pulling images and recreating containers.
+# =============================================================================
+
 services:
   watchtower:
     container_name: watchtower
@@ -5,8 +28,10 @@ services:
     restart: unless-stopped
     environment:
       - TZ=Asia/Kolkata
+      # Pin Docker API version for compatibility
       - DOCKER_API_VERSION=1.40
     volumes:
+      # Docker socket for inspecting and recreating containers (read-only)
       - /var/run/docker.sock:/var/run/docker.sock:ro
     command:
       - --interval


### PR DESCRIPTION
## Summary

- Added comprehensive inline YAML comments to all 10 docker-compose stack files
- Each file now has a header block explaining purpose, architecture, access hostname, internal port, and operational notes
- Per-service comments explain role, volume mounts, networking choices, and configuration rationale
- All 10 stacks pass `docker compose config` validation

## Files changed

- `docker-compose/pihole/` - DNS authority, wildcard rule, Pi-hole v6 FTLCONF requirement
- `docker-compose/nginx-proxy-manager/` - TLS termination, SNI routing, boot race condition
- `docker-compose/jellyfin-arr-stack/` - Full media pipeline data flow, GPU transcoding, hardlink strategy
- `docker-compose/immich/` - 4-service architecture, vector search DB, ML model caching
- `docker-compose/nextcloud-aio/` - Master container pattern, dual-hostname NPM setup
- `docker-compose/openclaw/` - Stateful gateway, manual-update-only warning, init signal handling
- `docker-compose/actual-budget/` - Simple service with backup priority note
- `docker-compose/uptime-kuma/` - WebSocket requirement for NPM proxy host
- `docker-compose/vaultwarden/` - Security setup sequence, DOMAIN env requirement
- `docker-compose/watchtower/` - Auto-update behavior, read-only socket, exclusion labels

## Test plan

- [x] All 10 stacks pass `docker compose config` with placeholder env vars
- [ ] CI validation workflow passes on this branch